### PR TITLE
[EDMT-320] 유저 마이페이지 로직 구현

### DIFF
--- a/edukit-api/build.gradle
+++ b/edukit-api/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 
 	// Health Check
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 // 실행 가능한 JAR 설정

--- a/edukit-api/src/main/java/com/edukit/api/common/config/SwaggerConfig.java
+++ b/edukit-api/src/main/java/com/edukit/api/common/config/SwaggerConfig.java
@@ -6,34 +6,22 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 
 @Configuration
 @RequiredArgsConstructor
 public class SwaggerConfig {
 
-    private final Environment environment;
-
     private static final String AUTHORIZATION = "Authorization";
-    private static final Map<String, String> PROFILE_SERVER_URL_MAP = Map.of(
-            "local", "http://localhost:8080",
-            "dev", "https://dev-api.edukit.co.kr",
-            "prod", "https://prod-api.edukit.co.kr"
-    );
 
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(info())
-                .servers(servers())
                 .addSecurityItem(securityRequirement())
                 .components(components());
     }
@@ -55,17 +43,6 @@ public class SwaggerConfig {
         info.title("Edukit API");
         info.description("Edukit API 명세서");
         return info;
-    }
-
-    private List<Server> servers() {
-        return PROFILE_SERVER_URL_MAP.entrySet().stream()
-                .filter(entry -> environment.matchesProfiles(entry.getKey()))
-                .map(entry -> {
-                    String url = entry.getValue();
-                    String description = "Edukit API " + entry.getKey();
-                    return new Server().url(url).description(description);
-                })
-                .toList();
     }
 
     private SecurityRequirement securityRequirement() {

--- a/edukit-api/src/main/java/com/edukit/api/common/config/SwaggerConfig.java
+++ b/edukit-api/src/main/java/com/edukit/api/common/config/SwaggerConfig.java
@@ -1,0 +1,84 @@
+package com.edukit.api.common.config;
+
+import com.edukit.api.common.annotation.MemberId;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    private final Environment environment;
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final Map<String, String> PROFILE_SERVER_URL_MAP = Map.of(
+            "local", "http://localhost:8080",
+            "dev", "https://dev-api.edukit.co.kr",
+            "prod", "https://prod-api.edukit.co.kr"
+    );
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(info())
+                .servers(servers())
+                .addSecurityItem(securityRequirement())
+                .components(components());
+    }
+
+    @Bean
+    public OperationCustomizer customizeOperation() {
+        return (operation, handlerMethod) -> {
+            boolean hasMemberId = Arrays.stream(handlerMethod.getMethodParameters())
+                    .anyMatch(param -> param.hasParameterAnnotation(MemberId.class));
+            if (hasMemberId) {
+                operation.getParameters().removeIf(param -> "memberId".equals(param.getName()));
+            }
+            return operation;
+        };
+    }
+
+    private Info info() {
+        Info info = new Info();
+        info.title("Edukit API");
+        info.description("Edukit API 명세서");
+        return info;
+    }
+
+    private List<Server> servers() {
+        return PROFILE_SERVER_URL_MAP.entrySet().stream()
+                .filter(entry -> environment.matchesProfiles(entry.getKey()))
+                .map(entry -> {
+                    String url = entry.getValue();
+                    String description = "Edukit API " + entry.getKey();
+                    return new Server().url(url).description(description);
+                })
+                .toList();
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList(AUTHORIZATION);
+    }
+
+    private Components components() {
+        SecurityScheme apiAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .name(AUTHORIZATION)
+                .in(SecurityScheme.In.HEADER)
+                .scheme("Bearer")
+                .bearerFormat("JWT");
+        return new Components().addSecuritySchemes(AUTHORIZATION, apiAuth);
+    }
+}

--- a/edukit-api/src/main/java/com/edukit/api/controller/auth/AuthController.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/auth/AuthController.java
@@ -50,6 +50,6 @@ public class AuthController {
     @DeleteMapping("/withdraw")
     public ResponseEntity<EdukitResponse<Void>> withdraw(@MemberId final long memberId) {
         authFacade.withdraw(memberId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body(EdukitResponse.success());
     }
 }

--- a/edukit-api/src/main/java/com/edukit/api/controller/auth/AuthController.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.edukit.api.controller.auth;
 
 import com.edukit.api.common.EdukitResponse;
+import com.edukit.api.common.annotation.MemberId;
 import com.edukit.api.controller.auth.request.MemberSignUpRequest;
 import com.edukit.api.security.handler.RefreshTokenCookieHandler;
 import com.edukit.api.security.util.PasswordValidator;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,5 +45,11 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .body(EdukitResponse.success(response));
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<EdukitResponse<Void>> withdraw(@MemberId final long memberId) {
+        authFacade.withdraw(memberId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/edukit-api/src/main/java/com/edukit/api/controller/member/MemberController.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/member/MemberController.java
@@ -1,0 +1,24 @@
+package com.edukit.api.controller.member;
+
+import com.edukit.api.common.EdukitResponse;
+import com.edukit.api.common.annotation.MemberId;
+import com.edukit.core.member.facade.MemberFacade;
+import com.edukit.core.member.facade.response.MemberProfileGetResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberFacade memberFacade;
+
+    @GetMapping("/profile")
+    public ResponseEntity<EdukitResponse<MemberProfileGetResponse>> getMemberProfile(@MemberId final long memberId) {
+        return ResponseEntity.ok().body(EdukitResponse.success(memberFacade.getMemberProfile(memberId)));
+    }
+}

--- a/edukit-api/src/main/java/com/edukit/api/controller/member/MemberController.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/member/MemberController.java
@@ -5,6 +5,7 @@ import com.edukit.api.common.annotation.MemberId;
 import com.edukit.api.controller.member.request.MemberProfileUpdateRequest;
 import com.edukit.core.member.enums.School;
 import com.edukit.core.member.facade.MemberFacade;
+import com.edukit.core.member.facade.response.MemberNicknameValidationResponse;
 import com.edukit.core.member.facade.response.MemberProfileGetResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,5 +37,13 @@ public class MemberController {
         School school = School.fromName(request.school());
         memberFacade.updateMemberProfile(memberId, request.subject(), school, request.nickname());
         return ResponseEntity.ok().body(EdukitResponse.success());
+    }
+
+    @GetMapping("/nickname")
+    public ResponseEntity<EdukitResponse<MemberNicknameValidationResponse>> validateNickname(
+            @MemberId final long memberId,
+            @RequestParam final String nickname
+    ) {
+        return ResponseEntity.ok().body(EdukitResponse.success(memberFacade.validateNickname(memberId, nickname)));
     }
 }

--- a/edukit-api/src/main/java/com/edukit/api/controller/member/MemberController.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/member/MemberController.java
@@ -2,11 +2,16 @@ package com.edukit.api.controller.member;
 
 import com.edukit.api.common.EdukitResponse;
 import com.edukit.api.common.annotation.MemberId;
+import com.edukit.api.controller.member.request.MemberProfileUpdateRequest;
+import com.edukit.core.member.enums.School;
 import com.edukit.core.member.facade.MemberFacade;
 import com.edukit.core.member.facade.response.MemberProfileGetResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +25,15 @@ public class MemberController {
     @GetMapping("/profile")
     public ResponseEntity<EdukitResponse<MemberProfileGetResponse>> getMemberProfile(@MemberId final long memberId) {
         return ResponseEntity.ok().body(EdukitResponse.success(memberFacade.getMemberProfile(memberId)));
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<EdukitResponse<Void>> updateMemberProfile(
+            @MemberId final long memberId,
+            @RequestBody @Valid final MemberProfileUpdateRequest request
+    ) {
+        School school = School.fromName(request.school());
+        memberFacade.updateMemberProfile(memberId, request.subject(), school, request.nickname());
+        return ResponseEntity.ok().body(EdukitResponse.success());
     }
 }

--- a/edukit-api/src/main/java/com/edukit/api/controller/member/request/MemberProfileUpdateRequest.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/member/request/MemberProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.edukit.api.controller.member.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MemberProfileUpdateRequest(
+        @NotNull(message = "과목은 필수 입력값입니다.")
+        String subject,
+        @NotNull(message = "학교는 필수 입력값입니다.")
+        String school,
+        @NotNull(message = "닉네임은 필수 입력값입니다.")
+        String nickname
+) {
+}

--- a/edukit-api/src/main/java/com/edukit/api/controller/notice/AdminNoticeApi.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/notice/AdminNoticeApi.java
@@ -1,0 +1,172 @@
+package com.edukit.api.controller.notice;
+
+import com.edukit.api.common.EdukitResponse;
+import com.edukit.api.controller.notice.request.NoticeCreateRequest;
+import com.edukit.api.controller.notice.request.NoticeUpdateRequest;
+import com.edukit.core.notice.facade.response.NoticeFileUploadPresignedUrlCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "관리자 공지사항", description = "관리자 공지사항 관리 API")
+public interface AdminNoticeApi {
+    @Operation(summary = "공지사항 생성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "필수 값 누락",
+                                            description = "카테고리 ID, 제목, 내용 중 하나라도 null인 경우",
+                                            value = """
+                                                      {
+                                                        "code": "FAIL-400",
+                                                        "message": "validation 오류",
+                                                        "data": {
+                                                          "categoryId": "카테고리 ID는 필수입니다.",
+                                                          "title": "제목은 필수입니다.",
+                                                          "content": "내용은 필수입니다."
+                                                        }
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "잘못된 카테고리 ID",
+                                            description = "유효하지 않은 공지사항 카테고리 ID를 입력한 경우",
+                                            value = """
+                                                      {
+                                                        "code": "NO-40001",
+                                                        "message": "유효하지 않은 공지사항 카테고리입니다."
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<Void>> createNotice(
+            @RequestBody @Valid final NoticeCreateRequest request
+    );
+
+    @Operation(summary = "공지사항 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "필수 값 누락",
+                                            description = "카테고리 ID, 제목, 내용 중 하나라도 null인 경우",
+                                            value = """
+                                                      {
+                                                        "code": "FAIL-400",
+                                                        "message": "validation 오류",
+                                                        "data": {
+                                                          "categoryId": "카테고리 ID는 필수입니다.",
+                                                          "title": "제목은 필수입니다.",
+                                                          "content": "내용은 필수입니다."
+                                                        }
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "잘못된 카테고리 ID",
+                                            description = "유효하지 않은 공지사항 카테고리 ID를 입력한 경우",
+                                            value = """
+                                                      {
+                                                        "code": "NO-40001",
+                                                        "message": "유효하지 않은 공지사항 카테고리입니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "공지사항 미존재",
+                                            description = "수정하려는 공지사항이 존재하지 않는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "NO-40402",
+                                                        "message": "해당 공지사항이 존재하지 않습니다."
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<Void>> updateNotice(
+            @RequestBody @Valid final NoticeUpdateRequest request,
+            @PathVariable final long noticeId
+    );
+
+    @Operation(summary = "공지사항 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "공지사항 미존재",
+                                            description = "삭제하려는 공지사항이 존재하지 않는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "NO-40402",
+                                                        "message": "해당 공지사항이 존재하지 않습니다."
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<Void>> deleteNotice(
+            @PathVariable final long noticeId
+    );
+
+    @Operation(summary = "파일 업로드용 Presigned URL 생성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "잘못된 파일명",
+                                            description = "파일명이 비어있거나 확장자가 없는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "S3-40001",
+                                                        "message": "잘못된 파일 이름입니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "지원하지 않는 파일 확장자",
+                                            description = "이미지 파일이 아닌 경우 (png, jpg, jpeg, gif, webp만 지원)",
+                                            value = """
+                                                      {
+                                                        "code": "S3-40002",
+                                                        "message": "지원하지 않는 파일 확장자입니다."
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<NoticeFileUploadPresignedUrlCreateResponse>> createFileUploadPresignedUrl(
+            @RequestParam final List<String> filenames
+    );
+}

--- a/edukit-api/src/main/java/com/edukit/api/controller/notice/AdminNoticeController.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/notice/AdminNoticeController.java
@@ -23,10 +23,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/admin/notices")
 @RequiredArgsConstructor
-public class AdminNoticeController {
+public class AdminNoticeController implements AdminNoticeApi {
 
     private final NoticeFacade noticeFacade;
 
+    @Override
     @PostMapping
     public ResponseEntity<EdukitResponse<Void>> createNotice(
             @RequestBody @Valid final NoticeCreateRequest request

--- a/edukit-api/src/main/java/com/edukit/api/controller/notice/NoticeApi.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/notice/NoticeApi.java
@@ -1,0 +1,82 @@
+package com.edukit.api.controller.notice;
+
+import com.edukit.api.common.EdukitResponse;
+import com.edukit.core.notice.facade.response.NoticeGetResponse;
+import com.edukit.core.notice.facade.response.NoticesGetResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "공지사항", description = "공지사항 관련 API")
+public interface NoticeApi {
+    @Operation(summary = "공지사항 목록 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "잘못된 카테고리 ID",
+                                            description = "유효하지 않은 공지사항 카테고리 ID를 입력한 경우",
+                                            value = """
+                                                      {
+                                                        "code": "NO-40001",
+                                                        "message": "유효하지 않은 공지사항 카테고리입니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "페이지 번호 validation 오류",
+                                            description = "페이지 번호가 1보다 작은 경우",
+                                            value = """
+                                                      {
+                                                        "code": "FAIL-400",
+                                                        "message": "validation 오류",
+                                                        "data": {
+                                                          "page": "1 이상이어야 합니다"
+                                                        }
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<NoticesGetResponse>> getNotices(
+            @RequestParam(name = "categoryId", required = false) Integer categoryId,
+            @RequestParam(name = "page", required = false, defaultValue = "1") @Min(1) int page
+    );
+
+    @Operation(summary = "공지사항 상세 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "공지사항 미존재",
+                                            description = "해당 ID의 공지사항이 존재하지 않는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "NO-40402",
+                                                        "message": "해당 공지사항이 존재하지 않습니다."
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<NoticeGetResponse>> getNotice(
+            @PathVariable final long noticeId
+    );
+}

--- a/edukit-api/src/main/java/com/edukit/api/controller/notice/NoticeController.java
+++ b/edukit-api/src/main/java/com/edukit/api/controller/notice/NoticeController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/notices")
 @RequiredArgsConstructor
-public class NoticeController {
+public class NoticeController implements NoticeApi {
 
     private final NoticeFacade noticeFacade;
 

--- a/edukit-api/src/main/java/com/edukit/api/security/config/SecurityConfig.java
+++ b/edukit-api/src/main/java/com/edukit/api/security/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SecurityWhitelist.AUTH_WHITELIST).permitAll()
                         .requestMatchers(SecurityWhitelist.BUSINESS_WHITE_LIST).permitAll()
+                        .requestMatchers(SecurityWhitelist.SWAGGER_WHITE_LIST).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/v2/student-records/ai-generate/**").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")

--- a/edukit-api/src/main/java/com/edukit/api/security/config/SecurityWhitelist.java
+++ b/edukit-api/src/main/java/com/edukit/api/security/config/SecurityWhitelist.java
@@ -22,12 +22,18 @@ public class SecurityWhitelist {
             "/api/v1/notices/{noticeId:\\d+}"
     };
 
+    protected static final String[] SWAGGER_WHITE_LIST = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
+    };
+
     private static final String[] ALL_WHITELIST;
 
     static {
         List<String> allWhitelist = new ArrayList<>();
         allWhitelist.addAll(Arrays.asList(AUTH_WHITELIST));
         allWhitelist.addAll(Arrays.asList(BUSINESS_WHITE_LIST));
+        allWhitelist.addAll(Arrays.asList(SWAGGER_WHITE_LIST));
         ALL_WHITELIST = allWhitelist.toArray(new String[0]);
     }
 

--- a/edukit-core/src/main/java/com/edukit/core/auth/facade/AuthFacade.java
+++ b/edukit-core/src/main/java/com/edukit/core/auth/facade/AuthFacade.java
@@ -56,4 +56,11 @@ public class AuthFacade {
             throw new AuthException(AuthErrorCode.FORBIDDEN_MEMBER);
         }
     }
+
+    @Transactional
+    public void withdraw(final long memberId) {
+        Member member = memberService.getMemberById(memberId);
+        memberService.withdraw(member);
+        //TODO refresh token 삭제
+    }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/entity/Member.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/entity/Member.java
@@ -110,4 +110,10 @@ public class Member extends BaseTimeEntity {
     public boolean isVerifyTeacher() {
         return this.role != MemberRole.PENDING_TEACHER;
     }
+
+    public void updateProfile(final Subject subject, final School school, final String nickname) {
+        this.subject = subject;
+        this.school = school;
+        this.nickname = nickname;
+    }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/entity/Member.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/entity/Member.java
@@ -106,4 +106,8 @@ public class Member extends BaseTimeEntity {
         this.role = MemberRole.PENDING_TEACHER;
         this.verifiedAt = null;
     }
+
+    public boolean isVerifyTeacher() {
+        return this.role != MemberRole.PENDING_TEACHER;
+    }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/entity/Member.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/entity/Member.java
@@ -116,4 +116,9 @@ public class Member extends BaseTimeEntity {
         this.school = school;
         this.nickname = nickname;
     }
+
+    public void withdraw() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/exception/MemberErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/exception/MemberErrorCode.java
@@ -10,7 +10,9 @@ public enum MemberErrorCode implements ErrorCode {
 
     MEMBER_NOT_FOUND("M-40401", "존재하지 않는 회원입니다. 회원가입을 진행해주세요."),
     MEMBER_ALREADY_REGISTERED("M-40902", "이미 등록된 회원입니다."),
-    INVALID_SCHOOL_TYPE("M-40003", "중학교, 고등학교 중 하나를 선택해주세요.")
+    INVALID_SCHOOL_TYPE("M-40003", "중학교, 고등학교 중 하나를 선택해주세요."),
+    INVALID_NICKNAME("EDMT-40004", "입력하신 닉네임은 유효하지 않습니다."),
+    DUPLICATED_NICKNAME("EDMT-40005", "입력하신 닉네임은 중복된 닉네임입니다."),
     ;
 
     private final String code;

--- a/edukit-core/src/main/java/com/edukit/core/member/exception/MemberErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/exception/MemberErrorCode.java
@@ -11,8 +11,8 @@ public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND("M-40401", "존재하지 않는 회원입니다. 회원가입을 진행해주세요."),
     MEMBER_ALREADY_REGISTERED("M-40902", "이미 등록된 회원입니다."),
     INVALID_SCHOOL_TYPE("M-40003", "중학교, 고등학교 중 하나를 선택해주세요."),
-    INVALID_NICKNAME("EDMT-40004", "입력하신 닉네임은 유효하지 않습니다."),
-    DUPLICATED_NICKNAME("EDMT-40005", "입력하신 닉네임은 중복된 닉네임입니다."),
+    INVALID_NICKNAME("M-40004", "입력하신 닉네임은 유효하지 않습니다."),
+    DUPLICATED_NICKNAME("M-40005", "입력하신 닉네임은 중복된 닉네임입니다."),
     ;
 
     private final String code;

--- a/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
@@ -20,7 +20,7 @@ public class MemberFacade {
 
     @Transactional(readOnly = true)
     public MemberProfileGetResponse getMemberProfile(final long memberId) {
-        Member member = memberService.getMemberById(memberId);
+        Member member = memberService.getMemberWithSubjectById(memberId);
         return MemberProfileGetResponse.of(
                 member.getEmail(), member.getSubject().getName(), member.isVerifyTeacher(),
                 member.getSchool().getName(), member.getNickname()

--- a/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
@@ -1,8 +1,11 @@
 package com.edukit.core.member.facade;
 
 import com.edukit.core.member.entity.Member;
+import com.edukit.core.member.enums.School;
 import com.edukit.core.member.facade.response.MemberProfileGetResponse;
 import com.edukit.core.member.service.MemberService;
+import com.edukit.core.subject.entity.Subject;
+import com.edukit.core.subject.service.SubjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberFacade {
 
     private final MemberService memberService;
+    private final SubjectService subjectService;
 
     @Transactional(readOnly = true)
     public MemberProfileGetResponse getMemberProfile(final long memberId) {
@@ -20,5 +24,13 @@ public class MemberFacade {
                 member.getEmail(), member.getSubject().getName(), member.isVerifyTeacher(),
                 member.getSchool().getName(), member.getNickname()
         );
+    }
+
+    @Transactional
+    public void updateMemberProfile(final long memberId, final String subjectName, final School school,
+                                    final String nickname) {
+        Member member = memberService.getMemberById(memberId);
+        Subject subject = subjectService.getSubjectByName(subjectName);
+        memberService.updateMemberProfile(member, subject, school, nickname);
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
@@ -1,0 +1,24 @@
+package com.edukit.core.member.facade;
+
+import com.edukit.core.member.entity.Member;
+import com.edukit.core.member.facade.response.MemberProfileGetResponse;
+import com.edukit.core.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberFacade {
+
+    private final MemberService memberService;
+
+    @Transactional(readOnly = true)
+    public MemberProfileGetResponse getMemberProfile(final long memberId) {
+        Member member = memberService.getMemberById(memberId);
+        return MemberProfileGetResponse.of(
+                member.getEmail(), member.getSubject().getName(), member.isVerifyTeacher(),
+                member.getSchool().getName(), member.getNickname()
+        );
+    }
+}

--- a/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/facade/MemberFacade.java
@@ -2,6 +2,7 @@ package com.edukit.core.member.facade;
 
 import com.edukit.core.member.entity.Member;
 import com.edukit.core.member.enums.School;
+import com.edukit.core.member.facade.response.MemberNicknameValidationResponse;
 import com.edukit.core.member.facade.response.MemberProfileGetResponse;
 import com.edukit.core.member.service.MemberService;
 import com.edukit.core.subject.entity.Subject;
@@ -32,5 +33,13 @@ public class MemberFacade {
         Member member = memberService.getMemberById(memberId);
         Subject subject = subjectService.getSubjectByName(subjectName);
         memberService.updateMemberProfile(member, subject, school, nickname);
+    }
+
+    public MemberNicknameValidationResponse validateNickname(final long memberId, final String nickname) {
+        Member member = memberService.getMemberById(memberId);
+        return MemberNicknameValidationResponse.of(
+                memberService.isNicknameInvalid(nickname),
+                memberService.isNicknameDuplicated(member, nickname)
+        );
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/facade/response/MemberNicknameValidationResponse.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/facade/response/MemberNicknameValidationResponse.java
@@ -1,0 +1,10 @@
+package com.edukit.core.member.facade.response;
+
+public record MemberNicknameValidationResponse(
+        boolean isInvalid,
+        boolean isDuplicated
+) {
+    public static MemberNicknameValidationResponse of(final boolean isInvalid, final boolean isDuplicated) {
+        return new MemberNicknameValidationResponse(isInvalid, isDuplicated);
+    }
+}

--- a/edukit-core/src/main/java/com/edukit/core/member/facade/response/MemberProfileGetResponse.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/facade/response/MemberProfileGetResponse.java
@@ -1,0 +1,17 @@
+package com.edukit.core.member.facade.response;
+
+public record MemberProfileGetResponse(
+        String email,
+        String subject,
+        boolean isTeacherVerified,
+        String school,
+        String nickname
+) {
+    public static MemberProfileGetResponse of(final String email,
+                                              final String subject,
+                                              final boolean isTeacherVerified,
+                                              final String school,
+                                              final String nickname) {
+        return new MemberProfileGetResponse(email, subject, isTeacherVerified, school, nickname);
+    }
+}

--- a/edukit-core/src/main/java/com/edukit/core/member/repository/MemberRepository.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package com.edukit.core.member.repository;
 import com.edukit.core.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -15,4 +17,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndIsDeleted(String email, boolean isDeleted);
 
     boolean existsByIdNotAndNicknameIgnoreCaseAndIsDeleted(long id, String nickname, boolean isDeleted);
+
+    @Query("SELECT m FROM Member m JOIN FETCH m.subject WHERE m.id = :id AND m.isDeleted = :isDeleted")
+    Optional<Member> findByIdAndIsDeletedFetchJoinSubject(@Param("id") long id, @Param("isDeleted") boolean isDeleted);
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/repository/MemberRepository.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByIdAndIsDeleted(long id, boolean isDeleted);
 
     boolean existsByEmailAndIsDeleted(String email, boolean isDeleted);
+
+    boolean existsByIdNotAndNicknameIgnoreCaseAndIsDeleted(long id, String nickname, boolean isDeleted);
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/repository/NicknameBannedWordRepository.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/repository/NicknameBannedWordRepository.java
@@ -1,0 +1,12 @@
+package com.edukit.core.member.repository;
+
+import com.edukit.core.member.entity.NicknameBannedWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NicknameBannedWordRepository extends JpaRepository<NicknameBannedWord, Long> {
+
+    @Query("SELECT COUNT(w) > 0 FROM NicknameBannedWord w WHERE :nickname LIKE CONCAT('%', w.word, '%')")
+    boolean existsBannedWordIn(@Param("nickname") String nickname);
+}

--- a/edukit-core/src/main/java/com/edukit/core/member/service/MemberService.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/service/MemberService.java
@@ -37,6 +37,12 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public Member getMemberWithSubjectById(final long memberId) {
+        return memberRepository.findByIdAndIsDeletedFetchJoinSubject(memberId, false)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
     @Transactional
     public Member createMember(final String email, final String encodedPassword, final Subject subject,
                                final String nickname, final School school) {

--- a/edukit-core/src/main/java/com/edukit/core/member/service/MemberService.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/service/MemberService.java
@@ -6,8 +6,10 @@ import com.edukit.core.member.enums.School;
 import com.edukit.core.member.exception.MemberErrorCode;
 import com.edukit.core.member.exception.MemberException;
 import com.edukit.core.member.repository.MemberRepository;
+import com.edukit.core.member.repository.NicknameBannedWordRepository;
 import com.edukit.core.subject.entity.Subject;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -18,8 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final NicknameBannedWordRepository nicknameBannedWordRepository;
 
     private static final boolean DELETED = true;
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,16}$");
 
     @Transactional(readOnly = true)
     public Member getMemberByUuid(final String memberUuid) {
@@ -41,6 +45,31 @@ public class MemberService {
         } catch (DataIntegrityViolationException e) {
             throw new MemberException(MemberErrorCode.MEMBER_ALREADY_REGISTERED);
         }
+    }
+
+    @Transactional
+    public void updateMemberProfile(final Member member, final Subject subject, final School school, final String nickname) {
+        validateNickname(member, nickname);
+        member.updateProfile(subject, school, nickname);
+    }
+
+    private void validateNickname(final Member member, final String nickname) {
+        if (isNicknameInvalid(nickname)) {
+            throw new MemberException(MemberErrorCode.INVALID_NICKNAME);
+        }
+        if (isNicknameDuplicated(member, nickname)) {
+            throw new MemberException(MemberErrorCode.DUPLICATED_NICKNAME);
+        }
+    }
+
+    public boolean isNicknameInvalid(final String nickname) {
+        return nickname.isBlank()
+                || !NICKNAME_PATTERN.matcher(nickname).matches()
+                || nicknameBannedWordRepository.existsBannedWordIn(nickname);
+    }
+
+    public boolean isNicknameDuplicated(final Member member, final String nickname) {
+        return memberRepository.existsByIdNotAndNicknameIgnoreCaseAndIsDeleted(member.getId(), nickname, false);
     }
 
     private Member saveMember(final String email, final String encodedPassword, final Subject subject,

--- a/edukit-core/src/main/java/com/edukit/core/member/service/MemberService.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/service/MemberService.java
@@ -72,6 +72,11 @@ public class MemberService {
         return memberRepository.existsByIdNotAndNicknameIgnoreCaseAndIsDeleted(member.getId(), nickname, false);
     }
 
+    @Transactional
+    public void withdraw(final Member member) {
+        member.withdraw();
+    }
+
     private Member saveMember(final String email, final String encodedPassword, final Subject subject,
                               final String nickname, final School school) {
         Optional<Member> restored = restoreIfSoftDeletedMemberByEmail(email, encodedPassword, subject, nickname,


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-320]

## 👩‍💻 작업 내용
프로필 조회, 프로필 업데이트, 닉네임 유효성 검사, 회원 탈퇴 API 구현했습니다.
Swagger 초기 설정과 공지사항 API 스웨거 명세서 작성했습니다.
Min 어노테이션에 대한 에러가 GlobalExceptionHandler에서 처리되지 않아 HandlerMethodValidationException 핸들러 추가했습니다.

## 📝 리뷰 요청 & 논의하고 싶은 내용
마이페이지 로직 중에 이메일 변경과 비밀번호 변경을 제외한 기능 구현했습니다.
스웨거 문서를 초안 형태로 먼저 작성해보았습니다. 수정하거나 보완했으면 하는 부분이 있으면 편하게 말씀해주세요

[EDMT-320]: https://bbangbbangz.atlassian.net/browse/EDMT-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * Swagger(OpenAPI) UI를 통한 API 문서 및 테스트 기능이 추가되었습니다.
  * 회원 프로필 조회, 수정, 닉네임 유효성 검사 API가 추가되었습니다.
  * 회원 탈퇴 기능이 추가되었습니다.
  * 관리자 공지사항 생성, 수정, 삭제, 파일 업로드 presigned URL 발급 API가 추가되었습니다.
  * 공지사항 목록 및 상세 조회 API가 추가되었습니다.

* **버그 수정**
  * 다양한 예외 상황에 대한 글로벌 예외처리 및 검증 오류 응답이 개선되었습니다.

* **보안**
  * Swagger 관련 엔드포인트가 인증 없이 접근 가능하도록 허용되었습니다.

* **기타**
  * 닉네임 금칙어/중복/형식 검증 로직이 추가되었습니다.
  * API 문서화 및 엔드포인트 명확화가 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->