### PR TITLE
[EDMT-294] OpenAI 연동 과정에 Resilience4j 서킷 브레이커 적용

### DIFF
--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/facade/StudentRecordAIFacade.java
@@ -36,7 +36,7 @@ public class StudentRecordAIFacade {
     }
 
     private StudentRecordCreateResponse mapToStudentRecordCreateResponse(final OpenAIVersionResponse response) {
-        return StudentRecordCreateResponse.of(response.versionNumber(), response.content(), response.isLast());
+        return StudentRecordCreateResponse.of(response.versionNumber(), response.content(), response.isLast(), response.isFallback());
     }
 
     /* v1.0.0

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/facade/response/StudentRecordCreateResponse.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/facade/response/StudentRecordCreateResponse.java
@@ -3,9 +3,14 @@ package com.edukit.core.studentrecord.facade.response;
 public record StudentRecordCreateResponse(
         int versionNumber,
         String content,
-        boolean isLast
+        boolean isLast,
+        boolean isFallback
 ) {
     public static StudentRecordCreateResponse of(final int versionNumber, final String content, final boolean isLast) {
-        return new StudentRecordCreateResponse(versionNumber, content, isLast);
+        return new StudentRecordCreateResponse(versionNumber, content, isLast, false);
+    }
+
+    public static StudentRecordCreateResponse of(final int versionNumber, final String content, final boolean isLast, final boolean isFallback) {
+        return new StudentRecordCreateResponse(versionNumber, content, isLast, isFallback);
     }
 }

--- a/edukit-external/build.gradle
+++ b/edukit-external/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 	implementation 'io.github.resilience4j:resilience4j-reactor:2.2.0'
 	implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
+
+	// Spring aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 

--- a/edukit-external/build.gradle
+++ b/edukit-external/build.gradle
@@ -23,6 +23,12 @@ dependencies {
 
 	// thymeleaf
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+	// Resilience4j
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+	implementation 'io.github.resilience4j:resilience4j-reactor:2.2.0'
+	implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 // 라이브러리 JAR 생성

--- a/edukit-external/src/main/java/com/edukit/external/ai/OpenAIService.java
+++ b/edukit-external/src/main/java/com/edukit/external/ai/OpenAIService.java
@@ -111,9 +111,9 @@ public class OpenAIService {
         }
 
         return Flux.just(
-                OpenAIVersionResponse.ofFallback(1, FALLBACK_MESSAGE + " (버전 1)", false),
-                OpenAIVersionResponse.ofFallback(2, FALLBACK_MESSAGE + " (버전 2)", false),
-                OpenAIVersionResponse.ofFallback(3, FALLBACK_MESSAGE + " (버전 3)", true)
+                OpenAIVersionResponse.ofFallback(1, FALLBACK_MESSAGE, false),
+                OpenAIVersionResponse.ofFallback(2, FALLBACK_MESSAGE, false),
+                OpenAIVersionResponse.ofFallback(3, FALLBACK_MESSAGE, true)
         );
     }
 

--- a/edukit-external/src/main/java/com/edukit/external/ai/OpenAIService.java
+++ b/edukit-external/src/main/java/com/edukit/external/ai/OpenAIService.java
@@ -111,9 +111,9 @@ public class OpenAIService {
         }
 
         return Flux.just(
-                OpenAIVersionResponse.of(1, FALLBACK_MESSAGE + " (버전 1)", false),
-                OpenAIVersionResponse.of(2, FALLBACK_MESSAGE + " (버전 2)", false),
-                OpenAIVersionResponse.of(3, FALLBACK_MESSAGE + " (버전 3)", true)
+                OpenAIVersionResponse.ofFallback(1, FALLBACK_MESSAGE + " (버전 1)", false),
+                OpenAIVersionResponse.ofFallback(2, FALLBACK_MESSAGE + " (버전 2)", false),
+                OpenAIVersionResponse.ofFallback(3, FALLBACK_MESSAGE + " (버전 3)", true)
         );
     }
 

--- a/edukit-external/src/main/java/com/edukit/external/ai/response/OpenAIVersionResponse.java
+++ b/edukit-external/src/main/java/com/edukit/external/ai/response/OpenAIVersionResponse.java
@@ -3,10 +3,15 @@ package com.edukit.external.ai.response;
 public record OpenAIVersionResponse(
         int versionNumber,
         String content,
-        boolean isLast
+        boolean isLast,
+        boolean isFallback
 ) {
 
     public static OpenAIVersionResponse of(final int versionNumber, final String content, final boolean isLast) {
-        return new OpenAIVersionResponse(versionNumber, content, isLast);
+        return new OpenAIVersionResponse(versionNumber, content, isLast, false);
+    }
+
+    public static OpenAIVersionResponse ofFallback(final int versionNumber, final String content, final boolean isLast) {
+        return new OpenAIVersionResponse(versionNumber, content, isLast, true);
     }
 }

--- a/edukit-external/src/main/java/com/edukit/external/config/CircuitBreakerConfig.java
+++ b/edukit-external/src/main/java/com/edukit/external/config/CircuitBreakerConfig.java
@@ -1,0 +1,31 @@
+package com.edukit.external.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class CircuitBreakerConfig {
+
+    @Bean
+    public CircuitBreaker openAiCircuitBreaker(final CircuitBreakerRegistry circuitBreakerRegistry) {
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("openai");
+
+        circuitBreaker.getEventPublisher()
+                .onStateTransition(event ->
+                        log.info("OpenAI Circuit breaker state transition: {} -> {}",
+                                event.getStateTransition().getFromState(),
+                                event.getStateTransition().getToState()))
+                .onCallNotPermitted(event ->
+                        log.warn("OpenAI Circuit breaker call not permitted"))
+                .onError(event ->
+                        log.error("OpenAI Circuit breaker error: {}", event.getThrowable().getMessage()))
+                .onSuccess(event ->
+                        log.debug("OpenAI Circuit breaker success"));
+
+        return circuitBreaker;
+    }
+}

--- a/edukit-external/src/main/java/com/edukit/external/config/CircuitBreakerConfig.java
+++ b/edukit-external/src/main/java/com/edukit/external/config/CircuitBreakerConfig.java
@@ -10,9 +10,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class CircuitBreakerConfig {
 
+    private static final String OPENAI_CIRCUIT_BREAKER_NAME = "openai";
+
     @Bean
     public CircuitBreaker openAiCircuitBreaker(final CircuitBreakerRegistry circuitBreakerRegistry) {
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("openai");
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker(OPENAI_CIRCUIT_BREAKER_NAME);
 
         circuitBreaker.getEventPublisher()
                 .onStateTransition(event ->

--- a/edukit-external/src/test/java/com/edukit/external/ai/OpenAIServiceCircuitBreakerTest.java
+++ b/edukit-external/src/test/java/com/edukit/external/ai/OpenAIServiceCircuitBreakerTest.java
@@ -1,0 +1,251 @@
+package com.edukit.external.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.edukit.external.ai.response.OpenAIVersionResponse;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("OpenAIService 서킷브레이커 테스트")
+class OpenAIServiceCircuitBreakerTest {
+
+    private CircuitBreaker circuitBreaker;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 서킷브레이커 설정 (빠른 테스트를 위해 짧은 시간 설정)
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .minimumNumberOfCalls(3)  // 최소 3번 호출 후 판단
+                .failureRateThreshold(70) // 70% 실패율
+                .waitDurationInOpenState(Duration.ofSeconds(1)) // 1초 후 HALF_OPEN
+                .permittedNumberOfCallsInHalfOpenState(2) // HALF_OPEN에서 2번 테스트
+                .slidingWindowSize(5) // 슬라이딩 윈도우 크기
+                .build();
+
+        CircuitBreakerRegistry registry = CircuitBreakerRegistry.of(config);
+        circuitBreaker = registry.circuitBreaker("test-openai");
+    }
+
+    @Test
+    @DisplayName("정상 상황에서 서킷브레이커가 CLOSED 상태를 유지해야 한다")
+    void shouldKeepCircuitBreakerClosedOnSuccess() {
+        // Given: 성공하는 작업
+        Supplier<String> successfulTask = () -> "성공";
+
+        // When: 성공적인 작업을 여러 번 실행
+        for (int i = 0; i < 5; i++) {
+            String result = circuitBreaker.executeSupplier(successfulTask);
+            assertThat(result).isEqualTo("성공");
+        }
+
+        // Then: 서킷브레이커가 CLOSED 상태를 유지
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(5);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("연속 실패 시 서킷브레이커가 OPEN 상태로 전환되어야 한다")
+    void shouldOpenCircuitBreakerOnConsecutiveFailures() {
+        // Given: 항상 실패하는 작업
+        Supplier<String> failingTask = () -> {
+            throw new RuntimeException("API 오류");
+        };
+
+        // When: 실패하는 작업을 연속으로 실행
+        for (int i = 0; i < 4; i++) {
+            try {
+                circuitBreaker.executeSupplier(failingTask);
+            } catch (Exception e) {
+                // 예외는 예상된 동작
+            }
+        }
+
+        // Then: 서킷브레이커가 OPEN 상태로 전환
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isGreaterThan(0);
+        assertThat(circuitBreaker.getMetrics().getFailureRate()).isGreaterThan(70.0f);
+    }
+
+    @Test
+    @DisplayName("OPEN 상태에서 호출 시 CallNotPermittedException이 발생해야 한다")
+    void shouldThrowCallNotPermittedExceptionWhenCircuitBreakerIsOpen() {
+        // Given: 서킷브레이커를 OPEN 상태로 만들기
+        Supplier<String> failingTask = () -> {
+            throw new RuntimeException("API 오류");
+        };
+
+        // 서킷브레이커를 OPEN 상태로 만들기
+        for (int i = 0; i < 4; i++) {
+            try {
+                circuitBreaker.executeSupplier(failingTask);
+            } catch (Exception e) {
+                // 예외는 예상된 동작
+            }
+        }
+
+        // When & Then: OPEN 상태에서 호출 시 CallNotPermittedException 발생
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        
+        assertThatThrownBy(() -> circuitBreaker.executeSupplier(() -> "테스트"))
+                .isInstanceOf(CallNotPermittedException.class)
+                .hasMessageContaining("CircuitBreaker 'test-openai' is OPEN");
+    }
+
+    @Test
+    @DisplayName("wait duration 후 HALF_OPEN 상태로 전환되어야 한다")
+    void shouldTransitionToHalfOpenAfterWaitDuration() throws InterruptedException {
+        // Given: 서킷브레이커를 OPEN 상태로 만들기
+        Supplier<String> failingTask = () -> {
+            throw new RuntimeException("API 오류");
+        };
+
+        // 서킷브레이커를 OPEN 상태로 만들기
+        for (int i = 0; i < 4; i++) {
+            try {
+                circuitBreaker.executeSupplier(failingTask);
+            } catch (Exception e) {
+                // 예외는 예상된 동작
+            }
+        }
+
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // When: wait duration 대기 (1초)
+        Thread.sleep(1100);
+
+        // HALF_OPEN 상태에서 성공적인 작업 실행
+        Supplier<String> successfulTask = () -> "복구됨";
+
+        // Then: HALF_OPEN 상태로 전환되고 성공 시 CLOSED로 복구
+        for (int i = 0; i < 2; i++) {
+            String result = circuitBreaker.executeSupplier(successfulTask);
+            assertThat(result).isEqualTo("복구됨");
+        }
+
+        // 성공적인 호출 후 CLOSED 상태로 복구되어야 함
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+    }
+
+    @Test
+    @DisplayName("서킷브레이커 메트릭스가 올바르게 기록되어야 한다")
+    void shouldRecordMetricsCorrectly() {
+        // Given: 성공과 실패가 섞인 작업들
+        Supplier<String> successTask = () -> "성공";
+        Supplier<String> failTask = () -> {
+            throw new RuntimeException("실패");
+        };
+
+        // When: 성공 2번, 실패 3번 실행
+        for (int i = 0; i < 2; i++) {
+            circuitBreaker.executeSupplier(successTask);
+        }
+
+        for (int i = 0; i < 3; i++) {
+            try {
+                circuitBreaker.executeSupplier(failTask);
+            } catch (Exception e) {
+                // 예상된 예외
+            }
+        }
+
+        // Then: 메트릭스가 올바르게 기록됨
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(2);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(3);
+        assertThat(metrics.getFailureRate()).isEqualTo(60.0f); // 3/5 = 60%
+    }
+
+    @Test
+    @DisplayName("fallback 동작을 시뮬레이션해야 한다")
+    void shouldSimulateFallbackBehavior() {
+        // Given: 서킷브레이커를 OPEN 상태로 만들기
+        Supplier<String> failingTask = () -> {
+            throw new RuntimeException("OpenAI API 오류");
+        };
+
+        // 서킷브레이커를 OPEN 상태로 만들기
+        for (int i = 0; i < 4; i++) {
+            try {
+                circuitBreaker.executeSupplier(failingTask);
+            } catch (Exception e) {
+                // 예외는 예상된 동작
+            }
+        }
+
+        // When: OPEN 상태에서 fallback 로직 테스트
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        String fallbackResult;
+        try {
+            fallbackResult = circuitBreaker.executeSupplier(() -> "정상 응답");
+            // 이 코드는 실행되지 않아야 함 (OPEN 상태에서는 예외 발생)
+            assertThat(false).as("OPEN 상태에서는 CallNotPermittedException이 발생해야 함").isTrue();
+        } catch (CallNotPermittedException e) {
+            // OPEN 상태에서는 CallNotPermittedException이 발생하므로 fallback 처리
+            fallbackResult = "현재 AI 서비스에 일시적인 문제가 발생하여 요청을 처리할 수 없습니다.";
+            // 예외 메시지 검증
+            assertThat(e.getMessage()).contains("CircuitBreaker 'test-openai' is OPEN");
+        }
+
+        // Then: fallback 응답이 반환됨
+        assertThat(fallbackResult).contains("현재 AI 서비스에 일시적인 문제가 발생");
+    }
+
+    @Test
+    @DisplayName("OpenAI 서비스의 fallback 응답 형태를 검증해야 한다")
+    void shouldValidateFallbackResponseFormat() {
+        // Given: OpenAI 서비스의 fallback 응답과 동일한 형태
+        String fallbackMessage = "현재 AI 서비스에 일시적인 문제가 발생하여 요청을 처리할 수 없습니다. 잠시 후 다시 시도해 주세요.";
+        
+        List<OpenAIVersionResponse> fallbackResponses = List.of(
+                OpenAIVersionResponse.of(1, fallbackMessage + " (버전 1)", false),
+                OpenAIVersionResponse.of(2, fallbackMessage + " (버전 2)", false),
+                OpenAIVersionResponse.of(3, fallbackMessage + " (버전 3)", true)
+        );
+
+        // When & Then: fallback 응답 형태 검증
+        assertThat(fallbackResponses).hasSize(3);
+        
+        OpenAIVersionResponse version1 = fallbackResponses.get(0);
+        assertThat(version1.versionNumber()).isEqualTo(1);
+        assertThat(version1.content()).contains("현재 AI 서비스에 일시적인 문제가 발생");
+        assertThat(version1.isLast()).isFalse();
+
+        OpenAIVersionResponse version3 = fallbackResponses.get(2);
+        assertThat(version3.versionNumber()).isEqualTo(3);
+        assertThat(version3.isLast()).isTrue();
+    }
+
+    @Test
+    @DisplayName("비동기 환경에서 서킷브레이커가 올바르게 동작해야 한다")
+    void shouldWorkCorrectlyInAsyncEnvironment() throws Exception {
+        // Given: 비동기 작업들
+        CompletableFuture<String> future1 = CompletableFuture.supplyAsync(() ->
+                circuitBreaker.executeSupplier(() -> "비동기 성공 1"));
+        
+        CompletableFuture<String> future2 = CompletableFuture.supplyAsync(() ->
+                circuitBreaker.executeSupplier(() -> "비동기 성공 2"));
+
+        // When: 비동기 작업 완료 대기
+        String result1 = future1.get(5, TimeUnit.SECONDS);
+        String result2 = future2.get(5, TimeUnit.SECONDS);
+
+        // Then: 모든 작업이 성공하고 서킷브레이커는 CLOSED 상태 유지
+        assertThat(result1).isEqualTo("비동기 성공 1");
+        assertThat(result2).isEqualTo("비동기 성공 2");
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(2);
+    }
+}

--- a/edukit-external/src/test/java/com/edukit/external/ai/OpenAIServiceIntegrationTest.java
+++ b/edukit-external/src/test/java/com/edukit/external/ai/OpenAIServiceIntegrationTest.java
@@ -209,9 +209,9 @@ class OpenAIServiceIntegrationTest {
         String fallbackMessage = "현재 AI 서비스에 일시적인 문제가 발생하여 요청을 처리할 수 없습니다. 잠시 후 다시 시도해 주세요.";
 
         return List.of(
-                OpenAIVersionResponse.of(1, fallbackMessage + " (버전 1)", false),
-                OpenAIVersionResponse.of(2, fallbackMessage + " (버전 2)", false),
-                OpenAIVersionResponse.of(3, fallbackMessage + " (버전 3)", true)
+                OpenAIVersionResponse.ofFallback(1, fallbackMessage + " (버전 1)", false),
+                OpenAIVersionResponse.ofFallback(2, fallbackMessage + " (버전 2)", false),
+                OpenAIVersionResponse.ofFallback(3, fallbackMessage + " (버전 3)", true)
         );
     }
 }

--- a/edukit-external/src/test/java/com/edukit/external/ai/OpenAIServiceIntegrationTest.java
+++ b/edukit-external/src/test/java/com/edukit/external/ai/OpenAIServiceIntegrationTest.java
@@ -1,0 +1,217 @@
+package com.edukit.external.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.edukit.external.ai.response.OpenAIVersionResponse;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("서킷브레이커 실제 동작 시뮬레이션 테스트")
+class OpenAIServiceIntegrationTest {
+
+    private CircuitBreaker circuitBreaker;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 서킷브레이커 설정
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .minimumNumberOfCalls(2)  // 최소 2번 호출 후 판단
+                .failureRateThreshold(50) // 50% 실패율
+                .waitDurationInOpenState(Duration.ofSeconds(1)) // 1초 후 HALF_OPEN
+                .permittedNumberOfCallsInHalfOpenState(1) // HALF_OPEN에서 1번 테스트
+                .build();
+
+        CircuitBreakerRegistry registry = CircuitBreakerRegistry.of(config);
+        circuitBreaker = registry.circuitBreaker("test-openai-integration");
+    }
+
+    @Test
+    @DisplayName("OpenAI API 호출 시뮬레이션 - 성공 시나리오")
+    void shouldSimulateSuccessfulOpenAIApiCall() {
+        // Given: 성공적인 API 호출을 시뮬레이션하는 작업
+        Supplier<List<OpenAIVersionResponse>> successfulApiCall = () -> {
+            // 실제 OpenAIService의 성공적인 응답을 시뮬레이션
+            return List.of(
+                    OpenAIVersionResponse.of(1, "첫 번째 성공적인 응답", false),
+                    OpenAIVersionResponse.of(2, "두 번째 성공적인 응답", false),
+                    OpenAIVersionResponse.of(3, "세 번째 성공적인 응답", true)
+            );
+        };
+
+        // When: 서킷브레이커를 통해 성공적인 호출 실행
+        List<OpenAIVersionResponse> result = circuitBreaker.executeSupplier(successfulApiCall);
+
+        // Then: 정상 응답과 CLOSED 상태 확인
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).versionNumber()).isEqualTo(1);
+        assertThat(result.get(0).content()).contains("첫 번째 성공적인 응답");
+        assertThat(result.get(2).isLast()).isTrue();
+
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("OpenAI API 호출 실패 시 fallback 응답 제공")
+    void shouldProvideFallbackOnApiFailure() {
+        // Given: 실패하는 API 호출을 시뮬레이션
+        Supplier<List<OpenAIVersionResponse>> failingApiCall = () -> {
+            throw new RuntimeException("OpenAI API 서버 오류");
+        };
+
+        // When: 실패하는 호출을 서킷브레이커로 감싸고 fallback 제공
+        List<OpenAIVersionResponse> result;
+        try {
+            result = circuitBreaker.executeSupplier(failingApiCall);
+        } catch (Exception e) {
+            // fallback 응답 제공
+            result = createFallbackResponse();
+        }
+
+        // Then: fallback 응답 확인
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).content()).contains("현재 AI 서비스에 일시적인 문제가 발생");
+        assertThat(result.get(2).isLast()).isTrue();
+
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("연속 실패 시 서킷브레이커 OPEN 전환")
+    void shouldOpenCircuitBreakerOnConsecutiveFailures() {
+        // Given: 항상 실패하는 API 호출
+        Supplier<List<OpenAIVersionResponse>> alwaysFailingCall = () -> {
+            throw new RuntimeException("지속적인 OpenAI API 오류");
+        };
+
+        // When: 연속으로 실패하는 호출을 최소 호출 수만큼 실행
+        for (int i = 0; i < 3; i++) {
+            List<OpenAIVersionResponse> result;
+            try {
+                result = circuitBreaker.executeSupplier(alwaysFailingCall);
+            } catch (Exception e) {
+                result = createFallbackResponse();
+            }
+
+            // 모든 호출이 fallback 응답을 반환해야 함
+            assertThat(result).hasSize(3);
+            assertThat(result.getFirst().content()).contains("현재 AI 서비스에 일시적인 문제가 발생");
+        }
+
+        // Then: 서킷브레이커가 OPEN 상태로 전환
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isGreaterThan(0);
+        assertThat(circuitBreaker.getMetrics().getFailureRate()).isGreaterThan(50.0f);
+    }
+
+    @Test
+    @DisplayName("서킷브레이커 복구 시나리오 테스트")
+    void shouldTestCircuitBreakerRecoveryScenario() throws InterruptedException {
+        // Given: 서킷브레이커를 OPEN 상태로 만들기
+        Supplier<List<OpenAIVersionResponse>> failingCall = () -> {
+            throw new RuntimeException("일시적인 API 오류");
+        };
+
+        // 연속 실패로 OPEN 상태 만들기
+        for (int i = 0; i < 3; i++) {
+            try {
+                circuitBreaker.executeSupplier(failingCall);
+            } catch (Exception e) {
+                // 예외는 예상된 동작
+            }
+        }
+
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // When: wait duration 후 성공적인 호출
+        Thread.sleep(1100);
+
+        Supplier<List<OpenAIVersionResponse>> recoveredCall = () -> List.of(
+                OpenAIVersionResponse.of(1, "복구된 응답 1", false),
+                OpenAIVersionResponse.of(2, "복구된 응답 2", false),
+                OpenAIVersionResponse.of(3, "복구된 응답 3", true)
+        );
+
+        // HALF_OPEN 상태에서 성공적인 호출
+        List<OpenAIVersionResponse> result = circuitBreaker.executeSupplier(recoveredCall);
+
+        // Then: 정상 응답을 받고 서킷브레이커가 CLOSED로 복구
+        assertThat(result).hasSize(3);
+        assertThat(result.getFirst().content()).contains("복구된 응답");
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+    }
+
+    @Test
+    @DisplayName("서킷브레이커 메트릭스가 실제 호출 결과를 반영해야 한다")
+    void shouldReflectActualCallResultsInMetrics() {
+        // Given: 성공이 더 많은 시나리오 (임계값 50%보다 낮은 실패율)
+        Supplier<List<OpenAIVersionResponse>> successCall = () -> List.of(
+                OpenAIVersionResponse.of(3, "성공적인 응답", true)
+        );
+
+        Supplier<List<OpenAIVersionResponse>> failCall = () -> {
+            throw new RuntimeException("API 호출 실패");
+        };
+
+        // When: 성공 3번, 실패 1번 (실패율 25%)
+        for (int i = 0; i < 3; i++) {
+            circuitBreaker.executeSupplier(successCall);
+        }
+
+        try {
+            circuitBreaker.executeSupplier(failCall);
+        } catch (Exception e) {
+            // 예외는 예상된 동작
+        }
+
+        // Then: 메트릭스 확인
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(3);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getFailureRate()).isEqualTo(25.0f); // 1/4 = 25%
+
+        // 실패율이 임계값(50%)보다 낮으므로 CLOSED 상태 유지
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+    }
+
+    @Test
+    @DisplayName("실제 OpenAI 서비스의 fallback 응답 형태 검증")
+    void shouldValidateOpenAIServiceFallbackFormat() {
+        // Given: OpenAI 서비스와 동일한 fallback 응답 생성
+        List<OpenAIVersionResponse> fallbackResponse = createFallbackResponse();
+
+        // When & Then: fallback 응답 형태 검증
+        assertThat(fallbackResponse).hasSize(3);
+
+        OpenAIVersionResponse version1 = fallbackResponse.getFirst();
+        assertThat(version1.versionNumber()).isEqualTo(1);
+        assertThat(version1.content()).contains("현재 AI 서비스에 일시적인 문제가 발생");
+        assertThat(version1.content()).contains("(버전 1)");
+        assertThat(version1.isLast()).isFalse();
+
+        OpenAIVersionResponse version3 = fallbackResponse.get(2);
+        assertThat(version3.versionNumber()).isEqualTo(3);
+        assertThat(version3.content()).contains("(버전 3)");
+        assertThat(version3.isLast()).isTrue();
+    }
+
+    /**
+     * 실제 OpenAIService의 fallback 응답과 동일한 형태를 생성
+     */
+    private List<OpenAIVersionResponse> createFallbackResponse() {
+        String fallbackMessage = "현재 AI 서비스에 일시적인 문제가 발생하여 요청을 처리할 수 없습니다. 잠시 후 다시 시도해 주세요.";
+
+        return List.of(
+                OpenAIVersionResponse.of(1, fallbackMessage + " (버전 1)", false),
+                OpenAIVersionResponse.of(2, fallbackMessage + " (버전 2)", false),
+                OpenAIVersionResponse.of(3, fallbackMessage + " (버전 3)", true)
+        );
+    }
+}


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-294]


## 👩‍💻 작업 내용
OpenAI(외부 서비스) 연동 시, 장애 전파를 막기 위한 서킷 브레이커 패턴을 적용하였습니다.
<!-- 작업 내용을 적어주세요 -->

## 📝 리뷰 요청 & 논의하고 싶은 내용
추가된 yml 파일 정보는 노션에 업데이트 해놨습니다.

---
### 선택한 방식
서킷 브레이커의 상태 전환 판단에는 슬라이딩 윈도우 기법이 사용되는데, 저희 서비스는 특정 시간대에 트래픽이 몰리고 요청량이 불규칙한 특성이 있어, 시간 기반 슬라이딩 윈도우 방식이 더 적합하다고 판단하여 해당 방식을 선택했습니다.
혹시 횟수 기반 방식이 더 적절하다고 보신다면 의견 부탁드립니다.

### fallback 메서드 구현
예외가 발생할 경우, 대체할 로직을 구현하였습니다. 이때, 예외가 발생되어 fallback 메서드가 수행되면 발생한 예외는 상위 메서드로 전파되지 않기 때문에 이와 관련해서 로직 수정이 조금 있습니다.
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📸 스크린 샷 (선택)
<img width="1021" height="349" alt="image" src="https://github.com/user-attachments/assets/d77735e8-a69b-4311-b54e-9370af7319c2" />


[EDMT-294]: https://bbangbbangz.atlassian.net/browse/EDMT-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * OpenAI 서비스에 회로 차단기(Circuit Breaker) 내결함성 기능이 추가되어, 장애 발생 시 자동으로 대체(폴백) 응답을 제공합니다.
  * 폴백 응답과 일반 응답을 구분하여 스트리밍 이벤트에서 별도의 이벤트 타입 및 안내 메시지를 제공합니다.

* **버그 수정**
  * 없음

* **테스트**
  * OpenAI 서비스의 회로 차단기 동작과 폴백 처리, 메트릭, 상태 전이 등을 검증하는 통합 및 단위 테스트가 추가되었습니다.

* **기타**
  * Resilience4j 및 AOP 관련 라이브러리 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->