### PR TITLE
[EDMT-316] 스웨거 에러 해결

### DIFF
--- a/edukit-api/src/main/java/com/edukit/common/annotation/MemberId.java
+++ b/edukit-api/src/main/java/com/edukit/common/annotation/MemberId.java
@@ -4,8 +4,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface MemberId {
 }

--- a/edukit-api/src/main/java/com/edukit/common/config/SwaggerConfig.java
+++ b/edukit-api/src/main/java/com/edukit/common/config/SwaggerConfig.java
@@ -1,15 +1,12 @@
 package com.edukit.common.config;
 
-import com.edukit.common.annotation.MemberId;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,18 +26,6 @@ public class SwaggerConfig {
                 .addServersItem(server())
                 .addSecurityItem(securityRequirement())
                 .components(components());
-    }
-
-    @Bean
-    public OperationCustomizer customizeOperation() {
-        return (operation, handlerMethod) -> {
-            boolean hasMemberId = Arrays.stream(handlerMethod.getMethodParameters())
-                    .anyMatch(param -> param.hasParameterAnnotation(MemberId.class));
-            if (hasMemberId) {
-                operation.getParameters().removeIf(param -> "memberId".equals(param.getName()));
-            }
-            return operation;
-        };
     }
 
     private Info info() {


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-316]

## 👩‍💻 작업 내용

<!-- 작업 내용을 적어주세요 -->
MemberId 어노테이션을 스웨거에서 숨기는 로직을 수정했습니다.


[EDMT-316]: https://bbangbbangz.atlassian.net/browse/EDMT-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서화
  - OpenAPI/Swagger에서 memberId 파라미터가 기본적으로 숨김 처리되어 엔드포인트 파라미터 목록에 표시되지 않습니다.
  - API 문서 가독성과 일관성이 개선되었습니다.
- 리팩터
  - 불필요한 문서 커스터마이징 로직을 제거하여 설정을 단순화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->