### PR TITLE
[EDMT-360] 생기부 응답 AI 생성 파이프라인 구축

### DIFF
--- a/.github/workflows/api-dev-cd.yml
+++ b/.github/workflows/api-dev-cd.yml
@@ -101,6 +101,7 @@ jobs:
           ECR_IMAGE_URI=${{ secrets.ECR_REGISTRY_URI }}/${{ secrets.ECR_REPOSITORY_NAME }}
           IMAGE_TAG=${{ needs.build.outputs.IMAGE_TAG }}
           MONITORING_INSTANCE=${{ secrets.MONITORING_INSTANCE }}
+          SERVER_ID=${{ matrix.runner }}
           EOF
 
       - name: Login to AWS ECR

--- a/edukit-api/src/main/java/com/edukit/auth/controller/v1/AuthV1Api.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/v1/AuthV1Api.java
@@ -390,7 +390,7 @@ public interface AuthV1Api {
                                             description = "인증 코드 입력 시도 횟수를 초과한 경우",
                                             value = """
                                                       {
-                                                        "code": "M-40013",
+                                                        "code": "A-40013",
                                                         "message": "인증 코드 시도 횟수를 초과했습니다. 인증 코드를 새로 발급받아주세요."
                                                       }
                                                     """

--- a/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
@@ -35,9 +35,7 @@ public class StudentRecordAIController {
     }
 
     @GetMapping(value = "/stream/{taskId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter streamStudentRecordResponse(
-            @MemberId final long memberId,
-            @PathVariable final long taskId) {
+    public SseEmitter streamStudentRecordResponse(@PathVariable final long taskId) {
 
         SseEmitter emitter = studentRecordAIFacade.createChannel(taskId);
 

--- a/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
@@ -7,12 +7,15 @@ import com.edukit.studentrecord.facade.StudentRecordAIFacade;
 import com.edukit.studentrecord.facade.response.StudentRecordTaskResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/v2/student-records")
@@ -29,5 +32,25 @@ public class StudentRecordAIController {
         StudentRecordTaskResponse response = studentRecordAIFacade.createTaskId(memberId, recordId,
                 request.byteCount(), request.prompt());
         return ResponseEntity.ok(EdukitResponse.success(response));
+    }
+
+    @GetMapping(value = "/stream/{taskId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamStudentRecordResponse(
+            @MemberId final long memberId,
+            @PathVariable final long taskId) {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+
+        // sseEmitterManager.add(taskId, emitter);
+
+        emitter.onCompletion(() -> {
+            // sseEmitterManager.remove(taskId);
+        });
+        emitter.onTimeout(() -> {
+            // sseEmitterManager.remove(taskId);
+            emitter.completeWithError(new RuntimeException("SSE Timeout"));
+            // sseEmitterManager.remove(taskId);
+        });
+
+        return emitter;
     }
 }

--- a/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
@@ -38,17 +38,18 @@ public class StudentRecordAIController {
     public SseEmitter streamStudentRecordResponse(
             @MemberId final long memberId,
             @PathVariable final long taskId) {
-        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
 
-        // sseEmitterManager.add(taskId, emitter);
+        SseEmitter emitter = studentRecordAIFacade.createChannel(taskId);
 
         emitter.onCompletion(() -> {
-            // sseEmitterManager.remove(taskId);
+            studentRecordAIFacade.closeChannel(taskId);
         });
         emitter.onTimeout(() -> {
-            // sseEmitterManager.remove(taskId);
             emitter.completeWithError(new RuntimeException("SSE Timeout"));
-            // sseEmitterManager.remove(taskId);
+            studentRecordAIFacade.closeChannel(taskId);
+        });
+        emitter.onError((throwable) -> {
+            studentRecordAIFacade.closeChannel(taskId);
         });
 
         return emitter;

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -1,6 +1,7 @@
 package com.edukit.studentrecord.facade;
 
 import com.edukit.core.studentrecord.db.entity.StudentRecord;
+import com.edukit.core.studentrecord.service.SSEChannelManager;
 import com.edukit.core.studentrecord.service.StudentRecordService;
 import com.edukit.core.studentrecord.util.AIPromptGenerator;
 import com.edukit.studentrecord.event.AITaskCreateEvent;
@@ -9,12 +10,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
 public class StudentRecordAIFacade {
 
     private final StudentRecordService studentRecordService;
+    private final SSEChannelManager sseChannelManager;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -28,5 +31,20 @@ public class StudentRecordAIFacade {
         eventPublisher.publishEvent(
                 AITaskCreateEvent.of(taskId, userPrompt, requestPrompt, byteCount, studentRecord.getId()));
         return StudentRecordTaskResponse.of(taskId);
+    }
+
+
+    public SseEmitter createChannel(final long taskId) {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        sseChannelManager.storeChannel(String.valueOf(taskId));
+        return emitter;
+    }
+
+    public void sendMessage(final long taskId, final String message) {
+
+    }
+
+    public void closeChannel(final long taskId) {
+        sseChannelManager.deleteChannel(String.valueOf(taskId));
     }
 }

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -25,7 +25,8 @@ public class StudentRecordAIFacade {
                                                   final String userPrompt) {
         StudentRecord studentRecord = studentRecordService.getRecordDetail(memberId, recordId);
 
-        String requestPrompt = AIPromptGenerator.createStreamingPrompt(studentRecord.getStudentRecordType(), byteCount, userPrompt);
+        String requestPrompt = AIPromptGenerator.createStreamingPrompt(studentRecord.getStudentRecordType(), byteCount,
+                userPrompt);
         long taskId = studentRecordService.createAITask(userPrompt);
 
         eventPublisher.publishEvent(
@@ -35,7 +36,7 @@ public class StudentRecordAIFacade {
 
 
     public SseEmitter createChannel(final long taskId) {
-        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
         sseChannelManager.registerTaskChannel(String.valueOf(taskId), emitter);
         return emitter;
     }

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -36,15 +36,11 @@ public class StudentRecordAIFacade {
 
     public SseEmitter createChannel(final long taskId) {
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
-        sseChannelManager.storeChannel(String.valueOf(taskId));
+        sseChannelManager.registerTaskChannel(String.valueOf(taskId), emitter);
         return emitter;
     }
 
-    public void sendMessage(final long taskId, final String message) {
-
-    }
-
     public void closeChannel(final long taskId) {
-        sseChannelManager.deleteChannel(String.valueOf(taskId));
+        sseChannelManager.removeChannel(String.valueOf(taskId));
     }
 }

--- a/edukit-common/src/main/java/com/edukit/common/ServerInstanceManager.java
+++ b/edukit-common/src/main/java/com/edukit/common/ServerInstanceManager.java
@@ -1,0 +1,27 @@
+package com.edukit.common;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Getter
+@Component
+public class ServerInstanceManager {
+
+    private final String serverId;
+
+    private static final String SERVER_PREFIX = "server-";
+    private static final String SERVER_ID_ENV_VAR = "SERVER_ID";
+
+    public ServerInstanceManager() {
+        this.serverId = System.getenv(SERVER_ID_ENV_VAR) != null
+                ? System.getenv(SERVER_ID_ENV_VAR)
+                : generateServerIdFromEC2Metadata();
+    }
+
+    private String generateServerIdFromEC2Metadata() {
+        return SERVER_PREFIX + UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/edukit-core/build.gradle
+++ b/edukit-core/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     // Jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+    // Spring Web for SSE support
+    implementation 'org.springframework:spring-web'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/edukit-core/build.gradle
+++ b/edukit-core/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Spring Web for SSE support
-    implementation 'org.springframework:spring-web'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/edukit-core/src/main/java/com/edukit/core/auth/exception/AuthErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/auth/exception/AuthErrorCode.java
@@ -20,7 +20,7 @@ public enum AuthErrorCode implements ErrorCode {
     PASSWORD_CONFIRM_MISMATCH("A-40010", "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     VERIFICATION_CODE_NOT_FOUND("A-40411", "유효한 인증 코드가 존재하지 않습니다."),
     DUPLICATED_NICKNAME("M-40012", "입력하신 닉네임은 중복된 닉네임입니다."),
-    VERIFICATION_CODE_ATTEMPT_LIMIT_EXCEEDED("M-40013", "인증 코드 시도 횟수를 초과했습니다. 인증 코드를 새로 발급받아주세요.");
+    VERIFICATION_CODE_ATTEMPT_LIMIT_EXCEEDED("A-40013", "인증 코드 시도 횟수를 초과했습니다. 인증 코드를 새로 발급받아주세요.");
 
     private final String code;
     private final String message;

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIResponseMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIResponseMessage.java
@@ -1,8 +1,9 @@
 package com.edukit.core.common.event.ai.dto;
 
 public record AIResponseMessage(
-        long taskId,
-        String data,
-        int version
+        Long taskId,
+        String reviewedContent,
+        Integer version,
+        Long recordId
 ) {
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIResponseMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIResponseMessage.java
@@ -1,0 +1,8 @@
+package com.edukit.core.common.event.ai.dto;
+
+public record AIResponseMessage(
+        long taskId,
+        String data,
+        int version
+) {
+}

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
@@ -23,6 +23,7 @@ public class SSEChannelManager {
     private final ConcurrentHashMap<String, SseEmitter> activeChannels = new ConcurrentHashMap<>();
 
     private static final String SSE_CHANNEL_PREFIX = "sse-channel:";
+    private static final String REDIS_CHANNEL = "ai-response";
 
     public void registerTaskChannel(final String taskId, final SseEmitter emitter) {
         String serverId = serverInstanceManager.getServerId();
@@ -39,12 +40,12 @@ public class SSEChannelManager {
         return activeChannels.containsKey(channelId);
     }
 
-    public void sendMessage(String taskId, AIResponseMessage message) {
+    public void sendMessage(final String taskId, final AIResponseMessage message) {
         SseEmitter emitter = activeChannels.get(taskId);
         if (emitter != null) {
             try {
                 emitter.send(SseEmitter.event()
-                        .name("ai-response")
+                        .name(REDIS_CHANNEL)
                         .data(message));
                 log.info("Sent message to SSE channel for taskId: {}", taskId);
             } catch (IOException e) {

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
@@ -23,6 +23,10 @@ public class SSEChannelManager {
         redisService.store(sseChannelKey(taskId), serverId, Duration.ofHours(1));
     }
 
+    public String get(final String channelId) {
+        return redisService.get(sseChannelKey(channelId));
+    }
+
     public boolean hasActivateChannel(final String channelId) {
         return redisService.get(sseChannelKey(channelId)) != null;
     }

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
@@ -1,0 +1,37 @@
+package com.edukit.core.studentrecord.service;
+
+
+import com.edukit.common.ServerInstanceManager;
+import com.edukit.core.common.service.RedisService;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@ConditionalOnBean(RedisService.class)
+public class SSEChannelManager {
+
+    private final RedisService redisService;
+    private final ServerInstanceManager serverInstanceManager;
+
+    private static final String SSE_CHANNEL_PREFIX = "sse-channel:";
+
+    public void storeChannel(final String taskId) {
+        String serverId = serverInstanceManager.getServerId();
+        redisService.store(sseChannelKey(taskId), serverId, Duration.ofHours(1));
+    }
+
+    public boolean hasActivateChannel(final String channelId) {
+        return redisService.get(sseChannelKey(channelId)) != null;
+    }
+
+    public void deleteChannel(final String channelId) {
+        redisService.delete(sseChannelKey(channelId));
+    }
+
+    private String sseChannelKey(final String channelId) {
+        return SSE_CHANNEL_PREFIX + channelId;
+    }
+}

--- a/edukit-external/src/main/java/com/edukit/external/redis/RedisMessageSubscriber.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/RedisMessageSubscriber.java
@@ -1,0 +1,19 @@
+package com.edukit.external.redis;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class RedisMessageSubscriber implements MessageListener {
+
+    @Override
+    public void onMessage(final Message message, final byte[] pattern) {
+        String msg = new String(message.getBody());
+        log.info("Received message from Redis: {}", msg);
+        // TODO: jobId → SSE push
+    }
+}
+

--- a/edukit-external/src/main/java/com/edukit/external/redis/RedisMessageSubscriber.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/RedisMessageSubscriber.java
@@ -1,7 +1,12 @@
 package com.edukit.external.redis;
 
+import com.edukit.common.ServerInstanceManager;
+import com.edukit.core.common.event.ai.dto.AIResponseMessage;
+import com.edukit.core.studentrecord.service.SSEChannelManager;
 import com.edukit.external.redis.exception.RedisErrorCode;
 import com.edukit.external.redis.exception.RedisException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -9,14 +14,33 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class RedisMessageSubscriber implements MessageListener {
+
+    private final ServerInstanceManager serverInstanceManager;
+    private final SSEChannelManager sseChannelManager;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void onMessage(final Message message, final byte[] pattern) {
         try {
             String msg = new String(message.getBody());
             log.info("Received message from Redis: {}", msg);
-            // TODO: jobId → SSE push
+
+            AIResponseMessage responseMessage = objectMapper.readValue(msg, AIResponseMessage.class);
+            String taskId = String.valueOf(responseMessage.taskId());
+
+            if (sseChannelManager.hasActivateChannel(taskId)) {
+                sseChannelManager.sendMessage(taskId, responseMessage);
+            } else {
+                String targetServerId = sseChannelManager.get(taskId);
+
+                if (targetServerId != null &&
+                        targetServerId.equals(serverInstanceManager.getServerId())) {
+                    log.warn("Task {} assigned to current server but no active channel", taskId);
+                    sseChannelManager.deleteChannel(taskId);
+                }
+            }
         } catch (Exception e) {
             log.error("Error processing Redis message: {}", e.getMessage(), e);
             throw new RedisException(RedisErrorCode.MESSAGE_PROCESSING_FAILED);

--- a/edukit-external/src/main/java/com/edukit/external/redis/RedisMessageSubscriber.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/RedisMessageSubscriber.java
@@ -1,5 +1,7 @@
 package com.edukit.external.redis;
 
+import com.edukit.external.redis.exception.RedisErrorCode;
+import com.edukit.external.redis.exception.RedisException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -11,9 +13,14 @@ public class RedisMessageSubscriber implements MessageListener {
 
     @Override
     public void onMessage(final Message message, final byte[] pattern) {
-        String msg = new String(message.getBody());
-        log.info("Received message from Redis: {}", msg);
-        // TODO: jobId → SSE push
+        try {
+            String msg = new String(message.getBody());
+            log.info("Received message from Redis: {}", msg);
+            // TODO: jobId → SSE push
+        } catch (Exception e) {
+            log.error("Error processing Redis message: {}", e.getMessage(), e);
+            throw new RedisException(RedisErrorCode.MESSAGE_PROCESSING_FAILED);
+        }
     }
 }
 

--- a/edukit-external/src/main/java/com/edukit/external/redis/config/RedisConfig.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/config/RedisConfig.java
@@ -1,11 +1,14 @@
 package com.edukit.external.redis.config;
 
+import com.edukit.external.redis.RedisMessageSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 
 @Configuration
 public class RedisConfig {
@@ -21,11 +24,25 @@ public class RedisConfig {
         this.port = port;
     }
 
+    private static final String DEFAULT_LISTENER_METHOD = "onMessage";
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(port);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(final RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter messageListenerAdapter(final RedisMessageSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, DEFAULT_LISTENER_METHOD);
     }
 }

--- a/edukit-external/src/main/java/com/edukit/external/redis/config/RedisSubscriber.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/config/RedisSubscriber.java
@@ -1,0 +1,24 @@
+package com.edukit.external.redis.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber {
+
+    private final RedisMessageListenerContainer container;
+    private final MessageListenerAdapter listenerAdapter;
+
+    @PostConstruct
+    public void init() {
+        container.addMessageListener(listenerAdapter, new ChannelTopic("ai-response"));
+        log.info("Subscribed to Redis channel: ai-response");
+    }
+}

--- a/edukit-external/src/main/java/com/edukit/external/redis/config/RedisSubscriber.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/config/RedisSubscriber.java
@@ -16,9 +16,11 @@ public class RedisSubscriber {
     private final RedisMessageListenerContainer container;
     private final MessageListenerAdapter listenerAdapter;
 
+    private static final String REDIS_CHANNEL = "ai-response";
+
     @PostConstruct
     public void init() {
-        container.addMessageListener(listenerAdapter, new ChannelTopic("ai-response"));
+        container.addMessageListener(listenerAdapter, new ChannelTopic(REDIS_CHANNEL));
         log.info("Subscribed to Redis channel: ai-response");
     }
 }

--- a/edukit-external/src/main/java/com/edukit/external/redis/exception/RedisErrorCode.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/exception/RedisErrorCode.java
@@ -1,0 +1,14 @@
+package com.edukit.external.redis.exception;
+
+import com.edukit.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisErrorCode implements ErrorCode {
+    MESSAGE_PROCESSING_FAILED("R-50001", "Redis 메시지 처리 중 오류가 발생했습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/edukit-external/src/main/java/com/edukit/external/redis/exception/RedisException.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/exception/RedisException.java
@@ -1,0 +1,10 @@
+package com.edukit.external.redis.exception;
+
+import com.edukit.common.exception.ExternalException;
+
+public class RedisException extends ExternalException {
+
+    public RedisException(final RedisErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-360]


## 👩‍💻 작업 내용
A2A 파이프라인을 완성하고, SSE 채널을 이용해서 응답을 클라이언트에게 반환하는 로직을 구현했습니다.

## 📝 리뷰 요청 & 논의하고 싶은 내용
전체적인 흐름은 아래와 같습니다.
1. 클라이언트 → Spring 서버
- 사용자가 Post 요청으로 입력값을 전송하면, Spring 애플리케이션은 작업 ID(Task ID) 를 즉시 생성하여 반환한다.

2. Spring 서버 → SQS → Lambda
- 생성된 작업 ID와 입력값은 SQS 큐를 통해 비동기적으로 전달된다. 여러 단계의 Lambda 함수가 이를 처리하면서 OpenAI API를 호출하여 응답을 생성한다.

3. 최종 Lambda → Redis Pub/Sub
- 마지막 Lambda 함수는 생성된 최종 결과를 Redis Pub/Sub 채널에 publish 한다.

4. Spring 서버 (Redis 구독)
- Spring 애플리케이션은 Redis의 특정 채널을 subscribe 하고 있다.
- 해당 서버에 해당 작업 ID와 매핑된 SSE 채널이 열려 있다면 → 즉시 클라이언트에게 SSE로 결과를 전송한다.
- 만약 채널이 없거나 다른 서버에서 SSE를 담당해야 한다면 → 다른 서버 인스턴스가 Redis Pub/Sub 메시지를 가져가 처리한다.
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📸 스크린 샷 (선택)


[EDMT-360]: https://bbangbbangz.atlassian.net/browse/EDMT-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 학생 기록 AI의 실시간 스트리밍(SSE) 지원 추가 — 진행 상황과 결과를 새로고침 없이 순차 수신 가능.
  - 서버 인스턴스 식별을 통한 노드 간 메시지 전달로 다중 서버 환경에서 실시간 응답 보장 강화.
- Refactor
  - 인증 시도 초과 오류 코드가 A-40013으로 변경되어 클라이언트 매핑 업데이트 필요.
- Chores
  - 배포 파이프라인에 SERVER_ID 환경변수 추가.
  - Redis 기반 메시지 구독 및 채널 관리 구성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->