### PR TITLE
[EDMT-375] RedisTemplate 빈(Bean) 중복 정의로 인한 충돌 해결

### DIFF
--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
@@ -8,11 +8,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StudentRecordErrorCode implements ErrorCode {
 
-    STUDENT_RECORD_NOT_FOUND("SR-40401", "해당 학생 기록이 존재하지 않습니다."),
+    AI("SR-40401", "해당 학생 기록이 존재하지 않습니다."),
     PERMISSION_DENIED("SR-40302", "해당 학생 기록에 대한 권한이 없습니다."),
     STUDENT_RECORD_TYPE_NOT_FOUND("SR-40403", "유효하지 않은 생활기록부 항목입니다."),
     DUPLICATE_RECORD_TYPE("SR-40004", "중복된 생활기록부 유형이 포함되어 있습니다."),
-    MESSAGE_PROCESSING_FAILED("R-50001", "Redis 메시지 처리 중 오류가 발생했습니다.");
+    MESSAGE_PROCESSING_FAILED("SR-50005", "Redis 메시지 처리 중 오류가 발생했습니다."),
+    AI_TASK_NOT_FOUND("SR-40406", "AI 작업을 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/StudentRecordService.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/StudentRecordService.java
@@ -44,7 +44,7 @@ public class StudentRecordService {
     @Transactional
     public void completeAITask(final Long taskId) {
         StudentRecordAITask aiTask = aiTaskRepository.findById(taskId)
-                .orElseThrow(() -> new StudentRecordException(StudentRecordErrorCode.STUDENT_RECORD_NOT_FOUND));
+                .orElseThrow(() -> new StudentRecordException(StudentRecordErrorCode.AI_TASK_NOT_FOUND));
         aiTask.complete();
     }
 
@@ -102,7 +102,7 @@ public class StudentRecordService {
 
     private StudentRecord getRecordDetailById(final long recordId) {
         return studentRecordRepository.findById(recordId)
-                .orElseThrow(() -> new StudentRecordException(StudentRecordErrorCode.STUDENT_RECORD_NOT_FOUND));
+                .orElseThrow(() -> new StudentRecordException(StudentRecordErrorCode.AI));
     }
 
     private void validatePermission(final Student student, final long memberId) {

--- a/edukit-external/src/main/java/com/edukit/external/redis/RedisStreamServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/RedisStreamServiceImpl.java
@@ -30,5 +30,4 @@ public class RedisStreamServiceImpl implements RedisStreamService {
     public void acknowledgeStreamMessage(final String groupName, final String streamKey, final RecordId messageId) {
         redisTemplate.opsForStream().acknowledge(groupName, streamKey, messageId);
     }
-
 }

--- a/edukit-external/src/main/java/com/edukit/external/redis/config/RedisConfig.java
+++ b/edukit-external/src/main/java/com/edukit/external/redis/config/RedisConfig.java
@@ -11,8 +11,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -34,17 +32,6 @@ public class RedisConfig {
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(port);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
-    }
-
-    @Bean
-    public RedisTemplate<String, String> redisTemplate(final RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-        template.setHashKeySerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(new StringRedisSerializer());
-        return template;
     }
 
     @Bean


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-375]


## 👩‍💻 작업 내용
RedisTemplate Bean 충돌을 해결하였습니다.

[EDMT-375]: https://bbangbbangz.atlassian.net/browse/EDMT-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터링
  - Redis 관련 내부 구성을 간소화하여 복잡도를 낮추고 유지보수성을 향상했습니다.
  - 사용자 기능이나 동작에는 변화가 없습니다.

- 스타일
  - 불필요한 공백 제거 등 경미한 코드 정리를 수행했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->