### PR TITLE
[EDMT-408] 공지사항 이미지 관리 방식 변경

### DIFF
--- a/edukit-api/src/main/java/com/edukit/admin/controller/AdminApi.java
+++ b/edukit-api/src/main/java/com/edukit/admin/controller/AdminApi.java
@@ -106,13 +106,7 @@ public interface AdminApi {
                     
                     **3단계: 공지사항 수정**
                     - category, title, content: 공지사항 정보
-                    - addedFileKeys: **새로 추가된 이미지의 fileKey 목록** (실제 본문에 포함된 것만)
-                    - deletedNoticeFileIds: **삭제할 기존 파일의 ID 목록** (1단계에서 조회한 파일 ID)
-                    
-                    **⚠️ 중요사항**
-                    - addedFileKeys: 새로 업로드한 파일 중 실제 본문에 사용된 것만 포함
-                    - deletedNoticeFileIds: 기존 파일 중 삭제할 파일의 DB ID (fileKey가 아님)
-                    - 두 필드 모두 선택사항이며 각각 독립적으로 처리됩니다
+                    - fileKeys: 최종적으로 본문에 포함된 fileKey 목록
                     """
     )
     @ApiResponses({

--- a/edukit-api/src/main/java/com/edukit/admin/controller/AdminController.java
+++ b/edukit-api/src/main/java/com/edukit/admin/controller/AdminController.java
@@ -43,8 +43,7 @@ public class AdminController implements AdminApi {
             @PathVariable final long noticeId
     ) {
         NoticeCategory category = NoticeCategory.from(request.category());
-        noticeFacade.updateNotice(noticeId, category, request.title(), request.content(), request.addedFileKeys(),
-                request.deletedNoticeFileIds());
+        noticeFacade.updateNotice(noticeId, category, request.title(), request.content(), request.fileKeys());
         return ResponseEntity.ok().body(EdukitResponse.success());
     }
 

--- a/edukit-api/src/main/java/com/edukit/admin/controller/request/NoticeUpdateRequest.java
+++ b/edukit-api/src/main/java/com/edukit/admin/controller/request/NoticeUpdateRequest.java
@@ -17,10 +17,7 @@ public record NoticeUpdateRequest(
         @NotNull(message = "내용은 필수입니다.")
         String content,
         
-        @Schema(description = "추가된 파일 키 목록", example = "[\"newfile.jpg\"]")
-        List<String> addedFileKeys,         //추가된 파일 목록
-        
-        @Schema(description = "삭제된 파일 ID 목록", example = "[1, 2]")
-        List<Long> deletedNoticeFileIds     //삭제된 파일 목록
+        @Schema(description = "게시물에 포함된 파일 키 목록", example = "[\"newfile.jpg\"]")
+        List<String> fileKeys
 ) {
 }

--- a/edukit-api/src/main/java/com/edukit/admin/controller/request/NoticeUpdateRequest.java
+++ b/edukit-api/src/main/java/com/edukit/admin/controller/request/NoticeUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.edukit.admin.controller.request;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -18,6 +20,7 @@ public record NoticeUpdateRequest(
         String content,
         
         @Schema(description = "게시물에 포함된 파일 키 목록", example = "[\"newfile.jpg\"]")
+        @JsonSetter(nulls = Nulls.AS_EMPTY)
         List<String> fileKeys
 ) {
 }

--- a/edukit-api/src/main/java/com/edukit/notice/controller/NoticeApi.java
+++ b/edukit-api/src/main/java/com/edukit/notice/controller/NoticeApi.java
@@ -98,7 +98,7 @@ public interface NoticeApi {
                                                 "title": "신규 기능 업데이트 안내",
                                                 "content": "새로운 AI 생활기록부 생성 기능이 추가되었습니다.",
                                                 "createdAt": "2024-01-15T10:30:00",
-                                                "noticeFileIds": [1, 2, 3]
+                                                "noticeFileKeys": ["file1.jpg", "file2.jpg"]
                                               }
                                             }
                                             """

--- a/edukit-api/src/main/java/com/edukit/notice/facade/NoticeFacade.java
+++ b/edukit-api/src/main/java/com/edukit/notice/facade/NoticeFacade.java
@@ -50,7 +50,7 @@ public class NoticeFacade {
                 notice.getTitle(),
                 notice.getContent(),
                 notice.getCreatedAt(),
-                noticeFiles.stream().map(NoticeFile::getId).toList()
+                noticeFiles.stream().map(NoticeFile::getFileKey).toList()
         );
     }
 
@@ -63,10 +63,8 @@ public class NoticeFacade {
     }
 
     public void updateNotice(final long noticeId, final NoticeCategory category, final String title,
-                             final String content, final List<String> addedFileKeys,
-                             final List<Long> deletedNoticeFileIds) {
-        NoticeUpdateResult result = noticeService.updateNoticeAndFiles(
-                noticeId, category, title, content, addedFileKeys, deletedNoticeFileIds);
+                             final String content, final List<String> fileKeys) {
+        NoticeUpdateResult result = noticeService.updateNoticeAndFiles(noticeId, category, title, content, fileKeys);
         if (result.hasAddedFiles()) {
             storageService.moveFiles(result.addedFileKeys(), TMP_NOTICE_FILE_DIRECTORY, NOTICE_FILE_DIRECTORY);
         }

--- a/edukit-api/src/main/java/com/edukit/notice/facade/response/NoticeGetResponse.java
+++ b/edukit-api/src/main/java/com/edukit/notice/facade/response/NoticeGetResponse.java
@@ -20,22 +20,22 @@ public record NoticeGetResponse(
         @Schema(description = "생성 날짜", example = "2024-01-15T10:30:00")
         LocalDateTime createdAt,
         
-        @Schema(description = "첨부 파일 ID 목록", example = "[1, 2, 3]")
-        List<Long> noticeFileIds
+        @Schema(description = "첨부된 파일 key 목록", example = "[\"newfile.jpg\"]")
+        List<String> noticeFileKeys
 ) {
     public static NoticeGetResponse of(final long noticeId,
                                        final String category,
                                        final String title,
                                        final String content,
                                        final LocalDateTime createdAt,
-                                       final List<Long> noticeFileIds) {
+                                       final List<String> noticeFileKeys) {
         return new NoticeGetResponse(
                 noticeId,
                 category,
                 title,
                 content,
                 createdAt,
-                noticeFileIds
+                noticeFileKeys
         );
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/notice/db/repository/NoticeFileRepository.java
+++ b/edukit-core/src/main/java/com/edukit/core/notice/db/repository/NoticeFileRepository.java
@@ -7,6 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeFileRepository extends JpaRepository<NoticeFile, Long> {
     List<NoticeFile> findByNotice(Notice notice);
-
-    List<NoticeFile> findByNoticeAndIdIn(Notice notice, List<Long> ids);
 }

--- a/edukit-core/src/main/java/com/edukit/core/notice/service/NoticeService.java
+++ b/edukit-core/src/main/java/com/edukit/core/notice/service/NoticeService.java
@@ -55,13 +55,15 @@ public class NoticeService {
                                                    final String title, final String content,
                                                    final List<String> fileKeys) {
         Notice notice = updateNotice(noticeId, category, title, content);
-        List<NoticeFile> existNoticeFiles = getNoticeFiles(notice);
 
+        List<NoticeFile> existNoticeFiles = getNoticeFiles(notice);
+        //파일 추가
         List<String> existNoticeFileKeys = existNoticeFiles.stream().map(NoticeFile::getFileKey).toList();
         List<String> addedNoticeFileKeys = fileKeys.stream().filter(fileKey -> !existNoticeFileKeys.contains(fileKey))
                 .toList();
         List<NoticeFile> addedNoticeFiles = createNoticeFiles(addedNoticeFileKeys, notice);
 
+        //파일 삭제
         List<NoticeFile> deletedNoticeFiles = existNoticeFiles.stream()
                 .filter(noticeFile -> !fileKeys.contains(noticeFile.getFileKey())).toList();
         deleteNoticeFiles(deletedNoticeFiles);
@@ -94,6 +96,9 @@ public class NoticeService {
     }
 
     private void deleteNoticeFiles(final List<NoticeFile> deletedNoticeFiles) {
+        if (deletedNoticeFiles.isEmpty()) {
+            return;
+        }
         noticeFileRepository.deleteAllByIdInBatch(deletedNoticeFiles.stream().map(NoticeFile::getId).toList());
     }
 


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-408]

## 👩‍💻 작업 내용

<!-- 작업 내용을 적어주세요 -->
공지사항 이미지 관리 방식 변경사항에 맞게 수정했습니다.


[EDMT-408]: https://bbangbbangz.atlassian.net/browse/EDMT-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 공지 첨부 파일 관리 방식 통합: 추가/삭제 리스트 대신 최종 fileKeys 목록으로 전달·저장.
  - 공지 조회 응답 필드 변경: noticeFileIds → noticeFileKeys(문자열 키).
  - 공지 수정 요청 스키마 변경: addedFileKeys/deletedNoticeFileIds 제거, fileKeys로 통일. 기존 클라이언트는 필드명 변경에 대응 필요.
- Documentation
  - API 설명 및 예시를 fileKeys 기준으로 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->