### PR TITLE
[EDMT-400] 비밀번호 찾기 시, 변경 링크 메일 전송 로직 구현

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,6 @@ services:
     environment:
       PROFILE: dev
       TZ: Asia/Seoul
-      SERVER_ID: ${SERVER_ID}
     ports:
       - "8080:8080"
     env_file:
@@ -13,7 +12,6 @@ services:
     restart: always
     volumes:
       - ./log:/log
-      - server-tmp:/tmp
     networks:
       - app-network
 
@@ -23,7 +21,6 @@ services:
     environment:
       PROFILE: dev
       TZ: Asia/Seoul
-      SERVER_ID: ${SERVER_ID}
     ports:
       - "8081:8080"
     env_file:
@@ -31,7 +28,6 @@ services:
     restart: always
     volumes:
       - ./log:/log
-      - server-tmp:/tmp
     networks:
       - app-network
 
@@ -56,14 +52,10 @@ services:
     volumes:
       - ./promtail-config.yml:/etc/promtail/config.yml
       - ./log:/log
-      - server-tmp:/tmp
     command: -config.expand-env=true -config.file=/etc/promtail/config.yml
     restart: always
     networks:
       - app-network
-
-volumes:
-  server-tmp:
 
 networks:
   app-network:

--- a/edukit-api/src/main/java/com/edukit/auth/controller/request/UpdatePasswordRequest.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/request/UpdatePasswordRequest.java
@@ -7,17 +7,13 @@ public record UpdatePasswordRequest(
         @Schema(description = "사용자 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
         @NotNull(message = "유저 uuid를 입력해주세요.")
         String memberUuid,
-        
+
         @Schema(description = "인증 코드", example = "123456")
         @NotNull(message = "인증 코드는 필수입니다.")
         String verificationCode,
-        
+
         @Schema(description = "새로운 비밀번호", example = "newSecurePassword123!")
         @NotNull(message = "새 비밀번호를 입력해주세요.")
-        String password,
-        
-        @Schema(description = "비밀번호 확인", example = "newSecurePassword123!")
-        @NotNull(message = "비밀번호 확인을 입력해주세요.")
-        String confirmPassword
+        String password
 ) {
 }

--- a/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
@@ -17,7 +17,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface AuthV2Api {
 
     @Operation(
-            summary = "비밀번호 찾기"
+            summary = "비밀번호 찾기",
+            description = "이메일로 비밀번호 재설정 페이지 링크를 발송합니다."
     )
     @ApiResponses({
             @ApiResponse(
@@ -82,7 +83,11 @@ public interface AuthV2Api {
     ResponseEntity<EdukitResponse<Void>> findPassword(@RequestBody @Valid final PasswordFindRequest request);
 
     @Operation(
-            summary = "비밀번호 변경"
+            summary = "비밀번호 변경",
+            description = """
+                    비밀번호 재설정 페이지에서 비밀번호를 변경합니다.
+                    재설정 페이지 링크: https://{도메인 주소}/reset-password?id=%s&code=%s
+                    """
     )
     @ApiResponses({
             @ApiResponse(

--- a/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
@@ -1,7 +1,198 @@
 package com.edukit.auth.controller.v2;
 
+import com.edukit.auth.controller.request.PasswordFindRequest;
+import com.edukit.auth.controller.request.UpdatePasswordRequest;
+import com.edukit.common.EdukitResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "인증/인가 Ver2", description = "회원가입 전 비밀번호 변경 API 등")
 public interface AuthV2Api {
+
+    @Operation(
+            summary = "비밀번호 찾기"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 찾기 이메일 발송 성공",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "요청이 성공했습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "필수 값 누락",
+                                            description = "이메일이 null인 경우",
+                                            value = """
+                                                      {
+                                                        "code": "FAIL-400",
+                                                        "message": "validation 오류",
+                                                        "data": {
+                                                          "email": "이메일 주소를 입력해주세요."
+                                                        }
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "이메일 형식 오류",
+                                            description = "유효하지 않은 이메일 형식인 경우",
+                                            value = """
+                                                      {
+                                                        "code": "FAIL-400",
+                                                        "message": "validation 오류",
+                                                        "data": {
+                                                          "email": "유효한 이메일 형식이 아닙니다."
+                                                        }
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "회원 미존재",
+                                            description = "입력한 이메일로 가입된 회원이 없는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "M-40401",
+                                                        "message": "존재하지 않는 회원입니다. 회원가입을 진행해주세요."
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<Void>> findPassword(@RequestBody @Valid final PasswordFindRequest request);
+
+    @Operation(
+            summary = "비밀번호 변경"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 변경 성공",
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "요청이 성공했습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "ERROR",
+                    content = @Content(
+                            examples = {
+                                    @ExampleObject(
+                                            name = "필수 값 누락",
+                                            description = "memberUuid, verificationCode, password, confirmPassword 중 하나라도 null인 경우",
+                                            value = """
+                                                      {
+                                                        "code": "FAIL-400",
+                                                        "message": "validation 오류",
+                                                        "data": {
+                                                          "memberUuid": "유저 uuid를 입력해주세요.",
+                                                          "verificationCode": "인증 코드는 필수입니다.",
+                                                          "password": "새 비밀번호를 입력해주세요.",
+                                                          "confirmPassword": "비밀번호 확인을 입력해주세요."
+                                                        }
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "비밀번호 형식 오류",
+                                            description = "비밀번호가 규칙에 맞지 않는 경우 (8-16자, 영문/숫자/특수문자 중 2가지 이상, 동일 문자 3번 연속 금지)",
+                                            value = """
+                                                      {
+                                                        "code": "A-40007",
+                                                        "message": "유효하지 않은 비밀번호 양식입니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "비밀번호 확인 불일치",
+                                            description = "새 비밀번호와 비밀번호 확인이 일치하지 않는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "A-40010",
+                                                        "message": "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "기존과 동일한 비밀번호",
+                                            description = "새로운 비밀번호가 기존 비밀번호와 같은 경우",
+                                            value = """
+                                                      {
+                                                        "code": "A-40009",
+                                                        "message": "새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "회원 미존재",
+                                            description = "memberUuid에 해당하는 회원이 존재하지 않는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "M-40401",
+                                                        "message": "존재하지 않는 회원입니다. 회원가입을 진행해주세요."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "인증 코드 미존재",
+                                            description = "유효한 인증 코드가 존재하지 않는 경우",
+                                            value = """
+                                                      {
+                                                        "code": "A-40411",
+                                                        "message": "유효한 인증 코드가 존재하지 않습니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "잘못된 인증 코드",
+                                            description = "인증 코드가 틀렸거나 만료된 경우",
+                                            value = """
+                                                      {
+                                                        "code": "A-40102",
+                                                        "message": "유효하지 않은 토큰입니다."
+                                                      }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "인증 코드 시도 횟수 초과",
+                                            description = "인증 코드 입력 시도 횟수를 초과한 경우",
+                                            value = """
+                                                      {
+                                                        "code": "A-40013",
+                                                        "message": "인증 코드 시도 횟수를 초과했습니다. 인증 코드를 새로 발급받아주세요."
+                                                      }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<EdukitResponse<Void>> updatePassword(@RequestBody @Valid final UpdatePasswordRequest request);
 }

--- a/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
@@ -106,7 +106,7 @@ public interface AuthV2Api {
                             examples = {
                                     @ExampleObject(
                                             name = "필수 값 누락",
-                                            description = "memberUuid, verificationCode, password, confirmPassword 중 하나라도 null인 경우",
+                                            description = "memberUuid, verificationCode, password 중 하나라도 null인 경우",
                                             value = """
                                                       {
                                                         "code": "FAIL-400",
@@ -114,8 +114,7 @@ public interface AuthV2Api {
                                                         "data": {
                                                           "memberUuid": "유저 uuid를 입력해주세요.",
                                                           "verificationCode": "인증 코드는 필수입니다.",
-                                                          "password": "새 비밀번호를 입력해주세요.",
-                                                          "confirmPassword": "비밀번호 확인을 입력해주세요."
+                                                          "password": "새 비밀번호를 입력해주세요."
                                                         }
                                                       }
                                                     """

--- a/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Api.java
@@ -130,16 +130,6 @@ public interface AuthV2Api {
                                                     """
                                     ),
                                     @ExampleObject(
-                                            name = "비밀번호 확인 불일치",
-                                            description = "새 비밀번호와 비밀번호 확인이 일치하지 않는 경우",
-                                            value = """
-                                                      {
-                                                        "code": "A-40010",
-                                                        "message": "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."
-                                                      }
-                                                    """
-                                    ),
-                                    @ExampleObject(
                                             name = "기존과 동일한 비밀번호",
                                             description = "새로운 비밀번호가 기존 비밀번호와 같은 경우",
                                             value = """

--- a/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Controller.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Controller.java
@@ -29,8 +29,7 @@ public class AuthV2Controller implements AuthV2Api {
     @PatchMapping("/password")
     public ResponseEntity<EdukitResponse<Void>> updatePassword(
             @RequestBody @Valid final UpdatePasswordRequest request) {
-        authFacade.updatePassword(request.memberUuid(), request.verificationCode(), request.password(),
-                request.confirmPassword());
+        authFacade.updatePassword(request.memberUuid(), request.verificationCode(), request.password());
         return ResponseEntity.ok(EdukitResponse.success());
     }
 }

--- a/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Controller.java
+++ b/edukit-api/src/main/java/com/edukit/auth/controller/v2/AuthV2Controller.java
@@ -26,11 +26,6 @@ public class AuthV2Controller implements AuthV2Api {
         return ResponseEntity.ok(EdukitResponse.success());
     }
 
-
-    /**
-     이거 없앨 지 말지 회의 -> 메일로 임시 비밀번호 제공해주는 쪽으로 변경할 지 의논해야함
-     지금은 비밀번호를 변경할 수 있는 링크를 제공하고 있음
-     */
     @PatchMapping("/password")
     public ResponseEntity<EdukitResponse<Void>> updatePassword(
             @RequestBody @Valid final UpdatePasswordRequest request) {

--- a/edukit-api/src/main/java/com/edukit/auth/facade/AuthFacade.java
+++ b/edukit-api/src/main/java/com/edukit/auth/facade/AuthFacade.java
@@ -96,10 +96,8 @@ public class AuthFacade {
     }
 
     @Transactional
-    public void updatePassword(final String memberUuid, final String verificationCode, final String newPassword,
-                               final String confirmPassword) {
+    public void updatePassword(final String memberUuid, final String verificationCode, final String newPassword) {
         PasswordValidator.validatePasswordFormat(newPassword);
-        PasswordValidator.validatePasswordEquality(newPassword, confirmPassword);
 
         Member member = memberService.getMemberByUuid(memberUuid);
         verificationCodeService.checkVerificationCode(member, verificationCode, VerificationCodeType.PASSWORD_RESET);

--- a/edukit-api/src/main/java/com/edukit/auth/facade/AuthFacade.java
+++ b/edukit-api/src/main/java/com/edukit/auth/facade/AuthFacade.java
@@ -16,7 +16,6 @@ import com.edukit.core.auth.service.VerificationCodeService;
 import com.edukit.core.auth.service.jwt.dto.AuthToken;
 import com.edukit.core.auth.util.PasswordValidator;
 import com.edukit.core.member.db.entity.Member;
-import com.edukit.core.member.db.enums.MemberRole;
 import com.edukit.core.member.db.enums.School;
 import com.edukit.core.member.service.MemberService;
 import com.edukit.core.subject.db.entity.Subject;
@@ -111,14 +110,6 @@ public class AuthFacade {
 
         String encodedPassword = passwordEncoder.encode(newPassword);
         memberService.updatePassword(member, encodedPassword);
-    }
-
-    @Transactional(readOnly = true)
-    public void checkHasPermission(final long memberId) {
-        Member member = memberService.getMemberById(memberId);
-        if (member.getRole() == MemberRole.PENDING_TEACHER) {
-            throw new AuthException(AuthErrorCode.FORBIDDEN_MEMBER);
-        }
     }
 
     @Transactional

--- a/edukit-api/src/main/java/com/edukit/common/security/config/SecurityWhitelist.java
+++ b/edukit-api/src/main/java/com/edukit/common/security/config/SecurityWhitelist.java
@@ -12,7 +12,7 @@ public class SecurityWhitelist {
             "/api/v1/auth/reissue",
             "/api/v2/auth/password",
             "/api/v1/auth/verify-email",
-            "/api/v1/auth/find-password",
+            "/api/v2/auth/find-password",
             "/api/v1/auth/nickname",
             "/actuator/health",
             "/actuator/prometheus"

--- a/edukit-common/src/main/java/com/edukit/common/infra/ServerInstanceManager.java
+++ b/edukit-common/src/main/java/com/edukit/common/infra/ServerInstanceManager.java
@@ -1,9 +1,5 @@
 package com.edukit.common.infra;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -18,28 +14,14 @@ public class ServerInstanceManager {
 
     private static final String SERVER_PREFIX = "server-";
     private static final String SERVER_ID_ENV_VAR = "SERVER_ID";
-    private static final String SERVER_ID_FILE_PATH = "/tmp/server-id.txt";
 
     public ServerInstanceManager() {
         this.serverId = System.getenv(SERVER_ID_ENV_VAR) != null
                 ? System.getenv(SERVER_ID_ENV_VAR)
                 : generateServerIdFromEC2Metadata();
-        
-        writeServerIdToFile();
     }
 
     private String generateServerIdFromEC2Metadata() {
         return SERVER_PREFIX + UUID.randomUUID().toString().substring(0, 8);
-    }
-
-    private void writeServerIdToFile() {
-        try {
-            Path path = Paths.get(SERVER_ID_FILE_PATH);
-            Files.createDirectories(path.getParent());
-            Files.write(path, serverId.getBytes());
-            log.info("Server ID written to file: {}", serverId);
-        } catch (IOException e) {
-            log.warn("Failed to write server ID to file: {}", e.getMessage());
-        }
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/auth/exception/AuthErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/auth/exception/AuthErrorCode.java
@@ -17,9 +17,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_PASSWORD_FORMAT("A-40007", "유효하지 않은 비밀번호 양식입니다."),
     INVALID_PASSWORD("A-40008", "비밀번호가 올바르지 않습니다."),
     SAME_PASSWORD("A-40009", "새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다."),
-    PASSWORD_CONFIRM_MISMATCH("A-40010", "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     VERIFICATION_CODE_NOT_FOUND("A-40411", "유효한 인증 코드가 존재하지 않습니다."),
-    DUPLICATED_NICKNAME("M-40012", "입력하신 닉네임은 중복된 닉네임입니다."),
     VERIFICATION_CODE_ATTEMPT_LIMIT_EXCEEDED("A-40013", "인증 코드 시도 횟수를 초과했습니다. 인증 코드를 새로 발급받아주세요.");
 
     private final String code;

--- a/edukit-core/src/main/java/com/edukit/core/auth/util/PasswordValidator.java
+++ b/edukit-core/src/main/java/com/edukit/core/auth/util/PasswordValidator.java
@@ -37,11 +37,5 @@ public class PasswordValidator {
             throw new AuthException(AuthErrorCode.INVALID_PASSWORD_FORMAT);
         }
     }
-
-    public static void validatePasswordEquality(final String newPassword, final String confirmedNewPassword) {
-        if (!newPassword.equals(confirmedNewPassword)) {
-            throw new AuthException(AuthErrorCode.PASSWORD_CONFIRM_MISMATCH);
-        }
-    }
 }
 

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
@@ -38,9 +38,7 @@ public class AIEventListener {
         log.info("AI 생기부 생성 시작 taskId: {}", taskId);
         aiTaskService.startTask(task);
 
-        // 현재 MDC 컨텍스트 캡처 (aiTaskExecutor에서 이미 전파됨)
         Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
-
         Flux<OpenAIVersionResponse> response = aiService.getVersionedStreamingResponse(generateEvent.requestPrompt());
 
         response
@@ -51,7 +49,6 @@ public class AIEventListener {
                     }
                 })
                 .doFinally(signalType -> {
-                    // 스트림 종료 시 MDC 정리 (메모리 누수 방지)
                     MDC.clear();
                 })
                 .subscribe(
@@ -71,7 +68,6 @@ public class AIEventListener {
                             } catch (ExternalException e) {
                                 log.error("SQS 메시지 전송 실패 - taskId: {}, error: {}", taskId, e.getMessage());
                             } finally {
-                                // 각 처리 후 MDC 정리
                                 MDC.clear();
                             }
                         },

--- a/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailEventListener.java
@@ -15,15 +15,18 @@ public class EmailEventListener {
 
     private final EmailService emailService;
 
+    private static final String SUBJECT_VERIFY = "[Edukit] 교사 인증을 위한 이메일입니다.";
+    private static final String SUBJECT_PASSWORD = "[Edukit] 비밀번호 변경을 위한 이메일입니다.";
+
     @Async("emailTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTeacherVerifyEmailEvent(final TeacherVerificationEmailEvent event) {
-        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode());
+        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_VERIFY);
     }
 
     @Async("emailTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePasswordFindEvent(final PasswordChangeEmailEvent event) {
-        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode());
+        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_PASSWORD);
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailEventListener.java
@@ -16,17 +16,20 @@ public class EmailEventListener {
     private final EmailService emailService;
 
     private static final String SUBJECT_VERIFY = "[Edukit] 교사 인증을 위한 이메일입니다.";
+    private static final String TEMPLATE_VERIFY = "email-verification";
+
     private static final String SUBJECT_PASSWORD = "[Edukit] 비밀번호 변경을 위한 이메일입니다.";
+    private static final String TEMPLATE_PASSWORD = "password-change";
 
     @Async("emailTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTeacherVerifyEmailEvent(final TeacherVerificationEmailEvent event) {
-        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_VERIFY);
+        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_VERIFY, TEMPLATE_VERIFY);
     }
 
     @Async("emailTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePasswordFindEvent(final PasswordChangeEmailEvent event) {
-        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_PASSWORD);
+        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_PASSWORD, TEMPLATE_PASSWORD);
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailEventListener.java
@@ -15,21 +15,15 @@ public class EmailEventListener {
 
     private final EmailService emailService;
 
-    private static final String SUBJECT_VERIFY = "[Edukit] 교사 인증을 위한 이메일입니다.";
-    private static final String TEMPLATE_VERIFY = "email-verification";
-
-    private static final String SUBJECT_PASSWORD = "[Edukit] 비밀번호 변경을 위한 이메일입니다.";
-    private static final String TEMPLATE_PASSWORD = "password-change";
-
     @Async("emailTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTeacherVerifyEmailEvent(final TeacherVerificationEmailEvent event) {
-        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_VERIFY, TEMPLATE_VERIFY);
+        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), EmailTemplate.TEACHER_VERIFY);
     }
 
     @Async("emailTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePasswordFindEvent(final PasswordChangeEmailEvent event) {
-        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), SUBJECT_PASSWORD, TEMPLATE_PASSWORD);
+        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode(), EmailTemplate.PASSWORD_CHANGE);
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailTemplate.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/mail/EmailTemplate.java
@@ -1,0 +1,15 @@
+package com.edukit.core.common.event.mail;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailTemplate {
+
+    TEACHER_VERIFY("[Edukit] 교사 인증을 위한 이메일입니다.", "email-verification"),
+    PASSWORD_CHANGE("[Edukit] 비밀번호 변경을 위한 이메일입니다.", "password-change");
+
+    private final String subject;
+    private final String templateKey;
+}

--- a/edukit-core/src/main/java/com/edukit/core/common/service/EmailService.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/service/EmailService.java
@@ -2,5 +2,5 @@ package com.edukit.core.common.service;
 
 public interface EmailService {
 
-    void sendEmail(String emailReceiver, String memberUuid, String verificationCode);
+    void sendEmail(String emailReceiver, String memberUuid, String verificationCode, String subject);
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/service/EmailService.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/service/EmailService.java
@@ -2,5 +2,5 @@ package com.edukit.core.common.service;
 
 public interface EmailService {
 
-    void sendEmail(String emailReceiver, String memberUuid, String verificationCode, String subject);
+    void sendEmail(String emailReceiver, String memberUuid, String verificationCode, String subject, String template);
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/service/EmailService.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/service/EmailService.java
@@ -1,6 +1,8 @@
 package com.edukit.core.common.service;
 
+import com.edukit.core.common.event.mail.EmailTemplate;
+
 public interface EmailService {
 
-    void sendEmail(String emailReceiver, String memberUuid, String verificationCode, String subject, String template);
+    void sendEmail(String emailReceiver, String memberUuid, String verificationCode, EmailTemplate emailTemplate);
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/db/repository/MemberRepository.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/db/repository/MemberRepository.java
@@ -1,9 +1,6 @@
 package com.edukit.core.member.db.repository;
 
 import com.edukit.core.member.db.entity.Member;
-import com.edukit.core.member.db.enums.MemberRole;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -23,16 +20,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM Member m JOIN FETCH m.subject WHERE m.id = :id AND m.isDeleted = :isDeleted")
     Optional<Member> findByIdAndIsDeletedFetchJoinSubject(@Param("id") long id, @Param("isDeleted") boolean isDeleted);
-
-    @Query("""
-            SELECT m FROM Member m 
-            WHERE m.isDeleted = false 
-            AND m.role = :role
-            AND m.verifiedAt < :lastVerificationCutoff
-            ORDER BY m.id
-            """)
-    List<Member> findTeachersForVerificationReset(@Param("role") MemberRole role,
-                                                  @Param("lastVerificationCutoff") LocalDateTime cutOffDate);
-
-    List<Member> findMembersByRoleAndIsDeleted(MemberRole role, boolean isDeleted);
 }

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/AwsSesEmailMapper.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/AwsSesEmailMapper.java
@@ -24,9 +24,9 @@ public class AwsSesEmailMapper {
 
     private static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
 
-    public SendEmailRequest buildEmailRequestForTeacherVerify(final String emailReceiver, final String memberUuid,
-                                                              final String verificationCode, final String subject,
-                                                              final String template) {
+    public SendEmailRequest buildEmailRequest(final String emailReceiver, final String memberUuid,
+                                              final String verificationCode, final String subject,
+                                              final String template) {
         String htmlBody = buildVerificationEmail(memberUuid, verificationCode, template);
         return buildSendEmailRequest(emailReceiver, subject, htmlBody);
     }
@@ -46,11 +46,8 @@ public class AwsSesEmailMapper {
         Body body = createBody(htmlBodyContent);
         Message message = createMessage(subjectContent, body);
 
-        return SendEmailRequest.builder()
-                .source(awsSesProperties.senderEmail())
-                .destination(destination)
-                .message(message)
-                .build();
+        return SendEmailRequest.builder().source(awsSesProperties.senderEmail()).destination(destination)
+                .message(message).build();
     }
 
     private String buildVerificationUrl(final String memberUuid, final String verificationCode) {
@@ -62,35 +59,22 @@ public class AwsSesEmailMapper {
     }
 
     private Destination createDestination(final String emailReceiver) {
-        return Destination.builder()
-                .toAddresses(emailReceiver)
-                .build();
+        return Destination.builder().toAddresses(emailReceiver).build();
     }
 
     private Content createSubjectContent(final String subject) {
-        return Content.builder()
-                .data(subject)
-                .charset(DEFAULT_CHARSET)
-                .build();
+        return Content.builder().data(subject).charset(DEFAULT_CHARSET).build();
     }
 
     private Content createHtmlBodyContent(final String htmlBody) {
-        return Content.builder()
-                .data(htmlBody)
-                .charset(DEFAULT_CHARSET)
-                .build();
+        return Content.builder().data(htmlBody).charset(DEFAULT_CHARSET).build();
     }
 
     private Body createBody(final Content htmlBodyContent) {
-        return Body.builder()
-                .html(htmlBodyContent)
-                .build();
+        return Body.builder().html(htmlBodyContent).build();
     }
 
     private Message createMessage(final Content subjectContent, final Body body) {
-        return Message.builder()
-                .subject(subjectContent)
-                .body(body)
-                .build();
+        return Message.builder().subject(subjectContent).body(body).build();
     }
 }

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/AwsSesEmailMapper.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/AwsSesEmailMapper.java
@@ -25,15 +25,17 @@ public class AwsSesEmailMapper {
     private static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
 
     public SendEmailRequest buildEmailRequestForTeacherVerify(final String emailReceiver, final String memberUuid,
-                                                              final String verificationCode, final String subject) {
-        String htmlBody = buildVerificationEmail(memberUuid, verificationCode);
+                                                              final String verificationCode, final String subject,
+                                                              final String template) {
+        String htmlBody = buildVerificationEmail(memberUuid, verificationCode, template);
         return buildSendEmailRequest(emailReceiver, subject, htmlBody);
     }
 
-    private String buildVerificationEmail(final String memberUuid, final String verificationCode) {
+    private String buildVerificationEmail(final String memberUuid, final String verificationCode,
+                                          final String template) {
         Context context = new Context();
         context.setVariable("verificationLink", buildVerificationUrl(memberUuid, verificationCode));
-        return templateEngine.process("email-verification", context);
+        return templateEngine.process(template, context);
     }
 
     public SendEmailRequest buildSendEmailRequest(final String emailReceiver, final String subject,

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/AwsSesEmailMapper.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/AwsSesEmailMapper.java
@@ -25,9 +25,9 @@ public class AwsSesEmailMapper {
     private static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
 
     public SendEmailRequest buildEmailRequestForTeacherVerify(final String emailReceiver, final String memberUuid,
-                                                              final String verificationCode) {
+                                                              final String verificationCode, final String subject) {
         String htmlBody = buildVerificationEmail(memberUuid, verificationCode);
-        return buildSendEmailRequest(emailReceiver, "[Edukit] 교사 인증 링크", htmlBody);
+        return buildSendEmailRequest(emailReceiver, subject, htmlBody);
     }
 
     private String buildVerificationEmail(final String memberUuid, final String verificationCode) {

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
@@ -20,10 +20,10 @@ public class EmailServiceImpl implements EmailService {
     private final AwsSesEmailMapper awsSesEmailMapper;
 
     public void sendEmail(final String emailReceiver, final String memberUuid, final String verificationCode,
-                          final String subject) {
+                          final String subject, final String template) {
         log.info("[SES] 이메일 발송 시작");
         SendEmailRequest request = awsSesEmailMapper.buildEmailRequestForTeacherVerify(emailReceiver, memberUuid,
-                verificationCode, subject);
+                verificationCode, subject, template);
         send(request, emailReceiver);
         log.info("[SES] 이메일 발송 성공");
     }

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
@@ -19,9 +19,11 @@ public class EmailServiceImpl implements EmailService {
     private final SesClient sesClient;
     private final AwsSesEmailMapper awsSesEmailMapper;
 
-    public void sendEmail(final String emailReceiver, final String memberUuid, final String verificationCode) {
+    public void sendEmail(final String emailReceiver, final String memberUuid, final String verificationCode,
+                          final String subject) {
         log.info("[SES] 이메일 발송 시작");
-        SendEmailRequest request = awsSesEmailMapper.buildEmailRequestForTeacherVerify(emailReceiver, memberUuid, verificationCode);
+        SendEmailRequest request = awsSesEmailMapper.buildEmailRequestForTeacherVerify(emailReceiver, memberUuid,
+                verificationCode, subject);
         send(request, emailReceiver);
         log.info("[SES] 이메일 발송 성공");
     }

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
@@ -23,8 +23,7 @@ public class EmailServiceImpl implements EmailService {
     public void sendEmail(final String emailReceiver, final String memberUuid, final String verificationCode,
                           final EmailTemplate emailTemplate) {
         log.info("[SES] 이메일 발송 시작");
-        SendEmailRequest request = awsSesEmailMapper.buildEmailRequest(emailReceiver, memberUuid, verificationCode,
-                emailTemplate.getSubject(), emailTemplate.getTemplateKey());
+        SendEmailRequest request = awsSesEmailMapper.buildEmailRequest(emailReceiver, memberUuid, verificationCode, emailTemplate);
         send(request, emailReceiver);
         log.info("[SES] 이메일 발송 성공");
     }

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package com.edukit.external.aws.mail;
 
+import com.edukit.core.common.event.mail.EmailTemplate;
 import com.edukit.core.common.service.EmailService;
 import com.edukit.external.aws.mail.exception.MailErrorCode;
 import com.edukit.external.aws.mail.exception.MailException;
@@ -20,10 +21,10 @@ public class EmailServiceImpl implements EmailService {
     private final AwsSesEmailMapper awsSesEmailMapper;
 
     public void sendEmail(final String emailReceiver, final String memberUuid, final String verificationCode,
-                          final String subject, final String template) {
+                          final EmailTemplate emailTemplate) {
         log.info("[SES] 이메일 발송 시작");
-        SendEmailRequest request = awsSesEmailMapper.buildEmailRequestForTeacherVerify(emailReceiver, memberUuid,
-                verificationCode, subject, template);
+        SendEmailRequest request = awsSesEmailMapper.buildEmailRequest(emailReceiver, memberUuid, verificationCode,
+                emailTemplate.getSubject(), emailTemplate.getTemplateKey());
         send(request, emailReceiver);
         log.info("[SES] 이메일 발송 성공");
     }

--- a/edukit-external/src/main/java/com/edukit/external/aws/mail/config/AwsSesProperties.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/mail/config/AwsSesProperties.java
@@ -6,7 +6,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record AwsSesProperties(
         String senderEmail,
         String region,
-        String emailVerifyUrl,
+        String teacherVerifyUrl,
+        String passwordResetUrl,
         int singleRequestTimeout,
         int totalCallTimeout
 ) {

--- a/edukit-external/src/main/java/com/edukit/external/common/config/AsyncConfig.java
+++ b/edukit-external/src/main/java/com/edukit/external/common/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.edukit.external.common.config;
 
 import com.edukit.external.common.handler.CustomAsyncExceptionHandler;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
@@ -59,7 +60,7 @@ public class AsyncConfig implements AsyncConfigurer {
     private static class MdcTaskDecorator implements TaskDecorator {
         @Override
         public Runnable decorate(final Runnable runnable) {
-            var contextMap = MDC.getCopyOfContextMap();
+            Map<String, String> contextMap = MDC.getCopyOfContextMap();
             return () -> {
                 if (contextMap != null) {
                     MDC.setContextMap(contextMap);

--- a/edukit-external/src/main/resources/templates/password-change.html
+++ b/edukit-external/src/main/resources/templates/password-change.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 변경</title>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap" rel="stylesheet">
+    <style>
+        .verification-button {
+            display: inline-block;
+            padding: 12px 24px;
+            background-color: #0d6efd;
+            color: #fff !important;
+            text-decoration: none;
+            border-radius: 6px;
+            margin-top: 20px;
+            font-weight: bold;
+            transition: background-color 0.3s ease;
+        }
+
+        .verification-button:hover {
+            background-color: #0b5ed7 !important;
+        }
+    </style>
+</head>
+<body style="font-family: 'Noto Sans KR', sans-serif; background-color: #f1f3f5; padding: 30px;">
+<div style="
+    max-width: 600px;
+    margin: auto;
+    background: #ffffff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+">
+    <h2 style="color: #212529; margin-bottom: 10px;">👋 안녕하세요</h2>
+    <p style="color: #495057;">비밀번호 변경 관련 안내 메일입니다.</p>
+    <p style="color: #495057;">아래 <strong>‘비밀번호 변경하기’</strong> 버튼을 눌러 새로운 비밀번호를 설정해주세요.</p>
+
+    <a th:href="${verificationLink}" class="verification-button">비밀번호 변경하기</a>
+</div>
+</body>
+</html>

--- a/promtail-config.yml
+++ b/promtail-config.yml
@@ -18,7 +18,7 @@ scrape_configs:
           job: api_error_logs
           module: api
           level: error
-          environment: ${ENVIRONMENT:-$(cat /tmp/server-id.txt 2>/dev/null || echo "unknown")}
+          environment: ${ENVIRONMENT}
           __path__: /log/error/*.log
     pipeline_stages:
       - json:
@@ -63,7 +63,7 @@ scrape_configs:
           job: api_info_logs
           module: api
           level: info
-          environment: ${ENVIRONMENT:-$(cat /tmp/server-id.txt 2>/dev/null || echo "unknown")}
+          environment: ${ENVIRONMENT}
           __path__: /log/info/*.log
     pipeline_stages:
       - json:
@@ -108,7 +108,7 @@ scrape_configs:
           job: api_warn_logs
           module: api
           level: warn
-          environment: ${ENVIRONMENT:-$(cat /tmp/server-id.txt 2>/dev/null || echo "unknown")}
+          environment: ${ENVIRONMENT}
           __path__: /log/warn/*.log
     pipeline_stages:
       - json:


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-400]


## 👩‍💻 작업 내용
회원가입 전, 비밀번호를 변경할 때, 변경 링크를 메일로 전송하는 로직을 구현했습니다.

## 📸 스크린 샷 (선택)
<img width="421" height="152" alt="image" src="https://github.com/user-attachments/assets/ed63a214-48d8-4f0b-b599-405a80e5726c" />


[EDMT-400]: https://bbangbbangz.atlassian.net/browse/EDMT-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<img width="1163" height="1776" alt="image" src="https://github.com/user-attachments/assets/173bb4f4-e090-439b-b7fc-ae369961570c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 비밀번호 찾기·변경 API(v2) 추가 및 해당 경로 화이트리스트 반영
  - 비밀번호 변경 요청 양식 간소화: 확인(Confirm) 입력 필드 제거
  - 비밀번호 변경 안내 이메일용 새 HTML 템플릿 추가 및 메일 발송이 템플릿·제목 기반으로 동작하도록 개선

- 작업(Chores)
  - 개발용 임시 볼륨 및 SERVER_ID 환경 변수 제거
  - 서버 ID 파일 쓰기 제거로 디스크 I/O 간소화
  - 로그 수집 설정에서 파일 기반 ENVIRONMENT 폴백 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->