### PR TITLE
[EDMT-374] 학생 도메인 인가 기능 추가

### DIFF
--- a/edukit-api/src/main/java/com/edukit/common/security/config/SecurityConfig.java
+++ b/edukit-api/src/main/java/com/edukit/common/security/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/v2/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v*/student-records/**").hasAnyRole("TEACHER", "ADMIN")
+                        .requestMatchers("/api/v*/students/**").hasAnyRole("TEACHER", "ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/edukit-api/src/main/java/com/edukit/student/controller/StudentController.java
+++ b/edukit-api/src/main/java/com/edukit/student/controller/StudentController.java
@@ -79,7 +79,7 @@ public class StudentController implements StudentApi {
                                                                            @RequestParam(required = false) final List<String> recordTypes,
                                                                            @RequestParam(required = false) final Long lastStudentId,
                                                                            @RequestParam(required = false, defaultValue = DEFAULT_PAGE_SIZE)
-                                                                               @Min(MIN_PAGE_SIZE) @Max(MAX_PAGE_SIZE) final int pageSize) {
+                                                                           @Min(MIN_PAGE_SIZE) @Max(MAX_PAGE_SIZE) final int pageSize) {
         List<StudentRecordType> studentRecordTypes = Optional.ofNullable(recordTypes).orElseGet(List::of).stream()
                 .map(StudentRecordType::from).toList();
         StudentsGetResponse response = studentFacade.getStudents(memberId, grades, classNumbers, studentRecordTypes,

--- a/edukit-api/src/main/java/com/edukit/student/controller/StudentController.java
+++ b/edukit-api/src/main/java/com/edukit/student/controller/StudentController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v1/student")
+@RequestMapping("/api/v1/students")
 @RequiredArgsConstructor
 public class StudentController implements StudentApi {
 


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-374]


## 👩‍💻 작업 내용
학생 Controller 부분에 인가 필터 동작을 추가했습니다.
<!-- 작업 내용을 적어주세요 -->



[EDMT-374]: https://bbangbbangz.atlassian.net/browse/EDMT-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 학생 관련 API 경로(/api/v*/students/**)에 권한 검증이 추가되어 TEACHER 또는 ADMIN만 접근 가능합니다.
- 리팩터링
  - 학생 API 기본 경로가 /api/v1/student에서 /api/v1/students로 변경되었습니다. 클라이언트는 새 경로로 요청을 전환해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->