### PR TITLE
[EDMT-404] SQS 메세지 전송 시 멱등키 추가

### DIFF
--- a/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
@@ -2,6 +2,8 @@ package com.edukit.studentrecord.controller;
 
 import com.edukit.common.EdukitResponse;
 import com.edukit.common.annotation.MemberId;
+import com.edukit.core.studentrecord.exception.StudentRecordErrorCode;
+import com.edukit.core.studentrecord.exception.StudentRecordException;
 import com.edukit.studentrecord.controller.request.StudentRecordPromptRequest;
 import com.edukit.studentrecord.facade.StudentRecordAIFacade;
 import com.edukit.studentrecord.facade.response.StudentRecordTaskResponse;
@@ -43,7 +45,7 @@ public class StudentRecordAIController implements StudentRecordAIApi {
             studentRecordAIFacade.closeChannel(taskId);
         });
         emitter.onTimeout(() -> {
-            emitter.completeWithError(new RuntimeException("SSE Timeout"));
+            emitter.completeWithError(new StudentRecordException(StudentRecordErrorCode.AI_GENERATE_TIMEOUT));
             studentRecordAIFacade.closeChannel(taskId);
         });
         emitter.onError((throwable) -> {

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
@@ -14,7 +14,8 @@ public enum StudentRecordErrorCode implements ErrorCode {
     DUPLICATE_RECORD_TYPE("SR-40004", "중복된 생활기록부 유형이 포함되어 있습니다."),
     MESSAGE_PROCESSING_FAILED("SR-50005", "Redis 메시지 처리 중 오류가 발생했습니다."),
     AI_TASK_NOT_FOUND("SR-40406", "AI 작업을 찾을 수 없습니다."),
-    AI_TASK_COMPLETION_FAILED("SR-50007", "AI 작업 완료에 실패했습니다.");
+    AI_TASK_COMPLETION_FAILED("SR-50007", "AI 작업 완료에 실패했습니다."),
+    AI_GENERATE_TIMEOUT("SR-50008", "AI 생성 요청이 시간 초과되었습니다.");
 
     private final String code;
     private final String message;

--- a/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
@@ -113,7 +113,7 @@ public class SqsServiceImpl implements SqsService {
             }
         } catch (Exception e) {
             log.debug("멱등성 키 추출 실패, 기본 처리: {}", e.getMessage());
+            throw new SQSException(SQSErrorCode.MESSAGE_SERIALIZATION_FAILED, e);
         }
-        return null;
     }
 }

--- a/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
@@ -113,7 +113,6 @@ public class SqsServiceImpl implements SqsService {
             }
         } catch (Exception e) {
             log.debug("멱등성 키 추출 실패, 기본 처리: {}", e.getMessage());
-            throw new SQSException(SQSErrorCode.MESSAGE_SERIALIZATION_FAILED, e);
         }
         return null;
     }

--- a/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
@@ -40,7 +40,8 @@ public class SqsServiceImpl implements SqsService {
 
             validateMessageSize(messageSizeBytes);
 
-            sendMessageInternal(messageBody);
+            String idempotencyKey = extractIdempotencyKey(message);
+            sendMessageInternal(messageBody, idempotencyKey);
 
         } catch (JsonProcessingException e) {
             log.error("SQS 메시지 직렬화 실패", e);
@@ -62,7 +63,7 @@ public class SqsServiceImpl implements SqsService {
         }
     }
 
-    private void sendMessageInternal(final String messageBody) {
+    private void sendMessageInternal(final String messageBody, final String idempotencyKey) {
         Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
 
         String traceId = MDC.get("traceId");
@@ -81,6 +82,13 @@ public class SqsServiceImpl implements SqsService {
                     .build());
         }
 
+        if (idempotencyKey != null) {
+            messageAttributes.put("idempotencyKey", MessageAttributeValue.builder()
+                    .dataType("String")
+                    .stringValue(idempotencyKey)
+                    .build());
+        }
+
         final SendMessageRequest request = SendMessageRequest.builder()
                 .queueUrl(sqsProperties.queueUrl())
                 .messageBody(messageBody)
@@ -88,6 +96,24 @@ public class SqsServiceImpl implements SqsService {
                 .build();
 
         final SendMessageResponse response = sqsClient.sendMessage(request);
-        log.info("SQS 메시지 전송 완료 - MessageId: {}, TraceId: {}", response.messageId(), traceId);
+        log.info("SQS 메시지 전송 완료 - MessageId: {}, TraceId: {}, IdempotencyKey: {}", 
+                response.messageId(), traceId, idempotencyKey);
+    }
+
+    private String extractIdempotencyKey(final Object message) {
+        try {
+            if (message.getClass().getSimpleName().equals("DraftGenerationEvent")) {
+                java.lang.reflect.Method getTaskId = message.getClass().getMethod("taskId");
+                java.lang.reflect.Method getVersion = message.getClass().getMethod("version");
+                long taskId = (Long) getTaskId.invoke(message);
+                int version = (Integer) getVersion.invoke(message);
+                String idempotencyKey = taskId + "-" + version;
+                log.debug("멱등성 키 생성: {}", idempotencyKey);
+                return idempotencyKey;
+            }
+        } catch (Exception e) {
+            log.debug("멱등성 키 추출 실패, 기본 처리: {}", e.getMessage());
+        }
+        return null;
     }
 }

--- a/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
@@ -115,5 +115,6 @@ public class SqsServiceImpl implements SqsService {
             log.debug("멱등성 키 추출 실패, 기본 처리: {}", e.getMessage());
             throw new SQSException(SQSErrorCode.MESSAGE_SERIALIZATION_FAILED, e);
         }
+        return null;
     }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-404]


## 👩‍💻 작업 내용
SQS에 메세지 전송 시 taskId + version 문자열 조합으로 멱등키를 추가하였습니다.



[EDMT-404]: https://bbangbbangz.atlassian.net/browse/EDMT-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 메시지 전송에 아이덴포턴시 키를 도입해 중복 처리 가능성을 줄였습니다.
- 버그 수정
  - AI 생성 요청이 시간 초과될 때 일반 오류 대신 명확한 도메인 오류로 안내되어 메시지와 처리 흐름이 일관되게 표시됩니다.
- 개선
  - 메시지 전송 로그에 아이덴포턴시 키가 포함되어 추적성이 향상됩니다.
  - 시간 초과 상황에서 스트림 종료 처리가 안정적으로 유지되어 사용자 경험이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->