### PR TITLE
[EDMT-406] 단계별 진행상황 전송

### DIFF
--- a/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIApi.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIApi.java
@@ -40,7 +40,7 @@ public interface StudentRecordAIApi {
                                               "code": "SUCCESS",
                                               "message": "요청이 성공했습니다.",
                                               "data": {
-                                                "taskId": 123
+                                                "taskId": "123"
                                               }
                                             }
                                             """
@@ -219,6 +219,6 @@ public interface StudentRecordAIApi {
                     description = "AI 생성 작업 ID",
                     required = true,
                     example = "123"
-            ) @PathVariable final long taskId
+            ) @PathVariable final String taskId
     );
 }

--- a/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIApi.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIApi.java
@@ -139,7 +139,7 @@ public interface StudentRecordAIApi {
     @Operation(
             summary = "AI 생활기록부 생성 결과 스트리밍",
             description = "AI 생활기록부 생성 작업의 결과를 실시간으로 스트리밍합니다. " +
-                         "응답이 3번 전송되면 자동으로 작업이 완료되고 연결이 종료됩니다."
+                         "진행 상태 메시지와 생성된 결과를 포함하며, 응답이 3번 전송되면 자동으로 작업이 완료되고 연결이 종료됩니다."
     )
     @ApiResponses({
             @ApiResponse(
@@ -151,14 +151,20 @@ public interface StudentRecordAIApi {
                                     type = "string",
                                     description = "Server-Sent Events 스트림",
                                     example = """
-                                            event: ai-response
-                                            data: {"taskId":123,"content":"생성된 생활기록부 내용 1","isComplete":false}
+                                            event: ai-message
+                                            data: {"taskId":"123","type":"PROGRESS","data":{"message":"3가지 버전 생성 중"}}
                                             
-                                            event: ai-response
-                                            data: {"taskId":123,"content":"생성된 생활기록부 내용 2","isComplete":false}
+                                            event: ai-message
+                                            data: {"taskId":"123","type":"RESPONSE","data":{"finalContent":"생성된 생활기록부 내용 1","version":1}}
                                             
-                                            event: ai-response
-                                            data: {"taskId":123,"content":"생성된 생활기록부 내용 3","isComplete":true}
+                                            event: ai-message
+                                            data: {"taskId":"123","type":"RESPONSE","data":{"finalContent":"생성된 생활기록부 내용 2","version":2}}
+                                            
+                                            event: ai-message
+                                            data: {"taskId":"123","type":"RESPONSE","data":{"finalContent":"생성된 생활기록부 내용 3","version":3}}
+                                            
+                                            event: ai-message
+                                            data: {"taskId":"123","type":"PROGRESS","data":{"message":"3가지 버전 생성 완료"}}
                                             """
                             )
                     )

--- a/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/controller/StudentRecordAIController.java
@@ -37,7 +37,7 @@ public class StudentRecordAIController implements StudentRecordAIApi {
     }
 
     @GetMapping(value = "/stream/{taskId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter streamStudentRecordResponse(@MemberId final long memberId, @PathVariable final long taskId) {
+    public SseEmitter streamStudentRecordResponse(@MemberId final long memberId, @PathVariable final String taskId) {
 
         SseEmitter emitter = studentRecordAIFacade.createChannel(memberId, taskId);
 

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -37,18 +37,18 @@ public class StudentRecordAIFacade {
         StudentRecordAITask task = aiTaskService.createAITask(member, userPrompt);
 
         eventPublisher.publishEvent(AITaskCreateEvent.of(task, userPrompt, requestPrompt, byteCount));
-        return StudentRecordTaskResponse.of(task.getId());
+        return StudentRecordTaskResponse.of(String.valueOf(task.getId()));
     }
 
-    public SseEmitter createChannel(final long memberId, final long taskId) {
+    public SseEmitter createChannel(final long memberId, final String taskId) {
         aiTaskService.validateUserTask(memberId, taskId);
 
         SseEmitter emitter = new SseEmitter(10 * 60 * 1000L);
-        sseChannelManager.registerTaskChannel(String.valueOf(taskId), emitter);
+        sseChannelManager.registerTaskChannel(taskId, emitter);
         return emitter;
     }
 
-    public void closeChannel(final long taskId) {
-        sseChannelManager.removeChannel(String.valueOf(taskId));
+    public void closeChannel(final String taskId) {
+        sseChannelManager.removeChannel(taskId);
     }
 }

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/response/StudentRecordTaskResponse.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/response/StudentRecordTaskResponse.java
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record StudentRecordTaskResponse(
         @Schema(description = "생성된 AI 작업 ID", example = "123")
-        long taskId
+        String taskId
 ) {
-    public static StudentRecordTaskResponse of(final long taskId) {
+    public static StudentRecordTaskResponse of(final String taskId) {
         return new StudentRecordTaskResponse(taskId);
     }
 }

--- a/edukit-api/src/main/resources/db/migration/V8__Remove_student_record_ai_task_columns.sql
+++ b/edukit-api/src/main/resources/db/migration/V8__Remove_student_record_ai_task_columns.sql
@@ -1,0 +1,4 @@
+-- Remove status column from student_record_ai_task table
+
+ALTER TABLE student_record_ai_task
+DROP COLUMN status;

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
@@ -36,13 +36,13 @@ public class AIEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleAIResponseGenerateEvent(final AIResponseGenerateEvent generateEvent) {
         StudentRecordAITask task = generateEvent.task();
-        long taskId = task.getId();
+        String taskId = String.valueOf(task.getId());
 
         log.info("AI 생기부 생성 시작 taskId: {}", taskId);
         aiTaskService.startTask(task);
 
         // SSE로 3가지 버전 생성 시작 알림
-        sseChannelManager.sendProgressMessage(String.valueOf(taskId), AIProgressMessage.generationStarted(taskId));
+        sseChannelManager.sendProgressMessage(taskId, AIProgressMessage.generationStarted(taskId));
 
         Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
         Flux<OpenAIVersionResponse> response = aiService.getVersionedStreamingResponse(generateEvent.requestPrompt());
@@ -93,9 +93,9 @@ public class AIEventListener {
                                     MDC.setContextMap(mdcContextMap);
                                 }
                                 log.info("AI 응답 생성 완료 - taskId: {}", taskId);
-                                
+
                                 // SSE로 3가지 버전 생성 완료 알림
-                                sseChannelManager.sendProgressMessage(String.valueOf(taskId), AIProgressMessage.generationCompleted(taskId));
+                                sseChannelManager.sendProgressMessage(taskId, AIProgressMessage.generationCompleted(taskId));
                             } finally {
                                 MDC.clear();
                             }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
@@ -1,6 +1,7 @@
 package com.edukit.core.common.event.ai;
 
 import com.edukit.common.exception.ExternalException;
+import com.edukit.core.common.event.ai.dto.AIProgressMessage;
 import com.edukit.core.common.event.ai.dto.DraftGenerationEvent;
 import com.edukit.core.common.service.AIService;
 import com.edukit.core.common.service.SqsService;
@@ -8,7 +9,6 @@ import com.edukit.core.common.service.response.OpenAIVersionResponse;
 import com.edukit.core.studentrecord.db.entity.StudentRecordAITask;
 import com.edukit.core.studentrecord.service.AITaskService;
 import com.edukit.core.studentrecord.service.SSEChannelManager;
-import com.edukit.core.common.event.ai.dto.AIProgressMessage;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -95,7 +95,8 @@ public class AIEventListener {
                                 log.info("AI 응답 생성 완료 - taskId: {}", taskId);
 
                                 // SSE로 3가지 버전 생성 완료 알림
-                                sseChannelManager.sendProgressMessage(taskId, AIProgressMessage.generationCompleted(taskId));
+                                sseChannelManager.sendProgressMessage(taskId,
+                                        AIProgressMessage.generationCompleted(taskId));
                             } finally {
                                 MDC.clear();
                             }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
@@ -70,7 +70,9 @@ public class AIEventListener {
                                         traceId
                                 );
                                 log.info("Task ID: {} VERSION {} 생성 완료! SQS 전송 시작", taskId, version.versionNumber());
-                                messageQueueService.sendMessage(event);
+
+                                String idempotencyKey = taskId + "-" + version.versionNumber();
+                                messageQueueService.sendMessage(event, idempotencyKey);
                             } catch (ExternalException e) {
                                 log.error("SQS 메시지 전송 실패 - taskId: {}, error: {}", taskId, e.getMessage());
                             } finally {

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
@@ -36,7 +36,6 @@ public class AIEventListener {
         long taskId = task.getId();
 
         log.info("AI 생기부 생성 시작 taskId: {}", taskId);
-        aiTaskService.startTask(task);
 
         Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
         Flux<OpenAIVersionResponse> response = aiService.getVersionedStreamingResponse(generateEvent.requestPrompt());

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/AIEventListener.java
@@ -36,6 +36,7 @@ public class AIEventListener {
         long taskId = task.getId();
 
         log.info("AI 생기부 생성 시작 taskId: {}", taskId);
+        aiTaskService.startTask(task);
 
         Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
         Flux<OpenAIVersionResponse> response = aiService.getVersionedStreamingResponse(generateEvent.requestPrompt());

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
@@ -1,22 +1,20 @@
 package com.edukit.core.common.event.ai.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.edukit.core.studentrecord.service.enums.AITaskStatus;
 
 public record AIProgressMessage(
-        @JsonProperty("task_id")
         String taskId,
-        @JsonProperty("message")
-        String message
+        AITaskStatus status
 ) {
-    public static AIProgressMessage of(final String taskId, final String message) {
-        return new AIProgressMessage(taskId, message);
+    public static AIProgressMessage of(final String taskId, final AITaskStatus status) {
+        return new AIProgressMessage(taskId, status);
     }
 
     public static AIProgressMessage generationStarted(final String taskId) {
-        return new AIProgressMessage(taskId, "3가지 버전 생성 중");
+        return new AIProgressMessage(taskId, AITaskStatus.PHASE1_STARTED);
     }
 
     public static AIProgressMessage generationCompleted(final String taskId) {
-        return new AIProgressMessage(taskId, "3가지 버전 생성 완료");
+        return new AIProgressMessage(taskId, AITaskStatus.PHASE1_COMPLETED);
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
@@ -1,0 +1,24 @@
+package com.edukit.core.common.event.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AIProgressMessage(
+        @JsonProperty("task_id")
+        Long taskId,
+        @JsonProperty("status")
+        String status,
+        @JsonProperty("message")
+        String message
+) {
+    public static AIProgressMessage of(final Long taskId, final String status, final String message) {
+        return new AIProgressMessage(taskId, status, message);
+    }
+    
+    public static AIProgressMessage generationStarted(final Long taskId) {
+        return new AIProgressMessage(taskId, "GENERATION_STARTED", "3가지 버전 생성 중");
+    }
+    
+    public static AIProgressMessage generationCompleted(final Long taskId) {
+        return new AIProgressMessage(taskId, "GENERATION_COMPLETED", "3가지 버전 생성 완료");
+    }
+}

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
@@ -4,19 +4,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record AIProgressMessage(
         @JsonProperty("task_id")
-        Long taskId,
+        String taskId,
         @JsonProperty("message")
         String message
 ) {
-    public static AIProgressMessage of(final Long taskId, final String message) {
+    public static AIProgressMessage of(final String taskId, final String message) {
         return new AIProgressMessage(taskId, message);
     }
 
-    public static AIProgressMessage generationStarted(final Long taskId) {
+    public static AIProgressMessage generationStarted(final String taskId) {
         return new AIProgressMessage(taskId, "3가지 버전 생성 중");
     }
 
-    public static AIProgressMessage generationCompleted(final Long taskId) {
+    public static AIProgressMessage generationCompleted(final String taskId) {
         return new AIProgressMessage(taskId, "3가지 버전 생성 완료");
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIProgressMessage.java
@@ -5,20 +5,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record AIProgressMessage(
         @JsonProperty("task_id")
         Long taskId,
-        @JsonProperty("status")
-        String status,
         @JsonProperty("message")
         String message
 ) {
-    public static AIProgressMessage of(final Long taskId, final String status, final String message) {
-        return new AIProgressMessage(taskId, status, message);
+    public static AIProgressMessage of(final Long taskId, final String message) {
+        return new AIProgressMessage(taskId, message);
     }
-    
+
     public static AIProgressMessage generationStarted(final Long taskId) {
-        return new AIProgressMessage(taskId, "GENERATION_STARTED", "3가지 버전 생성 중");
+        return new AIProgressMessage(taskId, "3가지 버전 생성 중");
     }
-    
+
     public static AIProgressMessage generationCompleted(final Long taskId) {
-        return new AIProgressMessage(taskId, "GENERATION_COMPLETED", "3가지 버전 생성 완료");
+        return new AIProgressMessage(taskId, "3가지 버전 생성 완료");
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIResponseMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/AIResponseMessage.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record AIResponseMessage(
         @JsonProperty("task_id")
-        Long taskId,
+        String taskId,
         @JsonProperty("final_content")
         String reviewedContent,
         @JsonProperty("version")

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/DraftGenerationEvent.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/DraftGenerationEvent.java
@@ -1,7 +1,7 @@
 package com.edukit.core.common.event.ai.dto;
 
 public record DraftGenerationEvent(
-        long taskId,
+        String taskId,
         String requestPrompt,
         int byteCount,
         int version,
@@ -9,7 +9,7 @@ public record DraftGenerationEvent(
         String traceId
 ) {
 
-    public static DraftGenerationEvent of(final long taskId, final String requestPrompt, final int byteCount,
+    public static DraftGenerationEvent of(final String taskId, final String requestPrompt, final int byteCount,
                                           final int version, final String draftContent, final String traceId) {
         return new DraftGenerationEvent(taskId, requestPrompt, byteCount, version, draftContent, traceId);
     }

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/SSEMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/SSEMessage.java
@@ -1,15 +1,15 @@
 package com.edukit.core.common.event.ai.dto;
 
 public record SSEMessage(
-        Long taskId,
+        String taskId,
         String type,
         Object data
 ) {
-    public static SSEMessage progress(final Long taskId, final String message) {
+    public static SSEMessage progress(final String taskId, final String message) {
         return new SSEMessage(taskId, "PROGRESS", new ProgressData(message));
     }
 
-    public static SSEMessage response(final Long taskId, final String finalContent, final Integer version) {
+    public static SSEMessage response(final String taskId, final String finalContent, final Integer version) {
         return new SSEMessage(taskId, "RESPONSE", new ResponseData(finalContent, version));
     }
 

--- a/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/SSEMessage.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/event/ai/dto/SSEMessage.java
@@ -1,0 +1,26 @@
+package com.edukit.core.common.event.ai.dto;
+
+public record SSEMessage(
+        Long taskId,
+        String type,
+        Object data
+) {
+    public static SSEMessage progress(final Long taskId, final String message) {
+        return new SSEMessage(taskId, "PROGRESS", new ProgressData(message));
+    }
+
+    public static SSEMessage response(final Long taskId, final String finalContent, final Integer version) {
+        return new SSEMessage(taskId, "RESPONSE", new ResponseData(finalContent, version));
+    }
+
+    public record ProgressData(
+            String message
+    ) {
+    }
+
+    public record ResponseData(
+            String finalContent,
+            Integer version
+    ) {
+    }
+}

--- a/edukit-core/src/main/java/com/edukit/core/common/service/SqsService.java
+++ b/edukit-core/src/main/java/com/edukit/core/common/service/SqsService.java
@@ -2,5 +2,5 @@ package com.edukit.core.common.service;
 
 public interface SqsService {
     
-    void sendMessage(Object message);
+    void sendMessage(Object message, String idempotencyKey);
 }

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/db/entity/StudentRecordAITask.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/db/entity/StudentRecordAITask.java
@@ -3,11 +3,8 @@ package com.edukit.core.studentrecord.db.entity;
 import static jakarta.persistence.FetchType.LAZY;
 
 import com.edukit.core.member.db.entity.Member;
-import com.edukit.core.studentrecord.db.enums.AITaskStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,20 +35,14 @@ public class StudentRecordAITask {
     @Column(nullable = false)
     private String prompt;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private AITaskStatus status;
-
     private LocalDateTime startedAt;
 
     private LocalDateTime completedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private StudentRecordAITask(final Member member, final String prompt, final AITaskStatus status,
-                                final LocalDateTime startedAt) {
+    private StudentRecordAITask(final Member member, final String prompt, final LocalDateTime startedAt) {
         this.member = member;
         this.prompt = prompt;
-        this.status = status;
         this.startedAt = startedAt;
     }
 
@@ -59,17 +50,14 @@ public class StudentRecordAITask {
         return StudentRecordAITask.builder()
                 .member(member)
                 .prompt(prompt)
-                .status(AITaskStatus.PENDING)
                 .build();
     }
 
     public void start() {
-        this.status = AITaskStatus.IN_PROGRESS;
         this.startedAt = LocalDateTime.now();
     }
 
     public void complete() {
-        this.status = AITaskStatus.COMPLETED;
         this.completedAt = LocalDateTime.now();
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/db/enums/AITaskStatus.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/db/enums/AITaskStatus.java
@@ -1,8 +1,0 @@
-package com.edukit.core.studentrecord.db.enums;
-
-public enum AITaskStatus {
-    PENDING,
-    IN_PROGRESS,
-    COMPLETED,
-    FAILED
-}

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
@@ -16,7 +16,8 @@ public enum StudentRecordErrorCode implements ErrorCode {
     AI_TASK_NOT_FOUND("SR-40406", "AI 작업을 찾을 수 없습니다."),
     AI_TASK_COMPLETION_FAILED("SR-50007", "AI 작업 완료에 실패했습니다."),
     AI_GENERATE_TIMEOUT("SR-50008", "AI 생성 요청이 시간 초과되었습니다."),
-    INVALID_AI_TASK_STATUS("SR-40009", "유효하지 않은 AI 작업 상태입니다.");
+    INVALID_AI_TASK_STATUS("SR-40009", "유효하지 않은 AI 작업 상태입니다."),
+    NUMBER_FORMAT_EXCEPTION("SR-40010", "숫자 형식이 올바르지 않습니다."),;
 
     private final String code;
     private final String message;

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/exception/StudentRecordErrorCode.java
@@ -15,7 +15,8 @@ public enum StudentRecordErrorCode implements ErrorCode {
     MESSAGE_PROCESSING_FAILED("SR-50005", "Redis 메시지 처리 중 오류가 발생했습니다."),
     AI_TASK_NOT_FOUND("SR-40406", "AI 작업을 찾을 수 없습니다."),
     AI_TASK_COMPLETION_FAILED("SR-50007", "AI 작업 완료에 실패했습니다."),
-    AI_GENERATE_TIMEOUT("SR-50008", "AI 생성 요청이 시간 초과되었습니다.");
+    AI_GENERATE_TIMEOUT("SR-50008", "AI 생성 요청이 시간 초과되었습니다."),
+    INVALID_AI_TASK_STATUS("SR-40009", "유효하지 않은 AI 작업 상태입니다.");
 
     private final String code;
     private final String message;

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/AITaskService.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/AITaskService.java
@@ -23,6 +23,11 @@ public class AITaskService {
     }
 
     @Transactional
+    public void startTask(final StudentRecordAITask task) {
+        task.start();
+    }
+
+    @Transactional
     public void completeAITask(final Long taskId) {
         StudentRecordAITask aiTask = aiTaskRepository.findById(taskId)
                 .orElseThrow(() -> new StudentRecordException(StudentRecordErrorCode.AI_TASK_NOT_FOUND));

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/AITaskService.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/AITaskService.java
@@ -23,11 +23,6 @@ public class AITaskService {
     }
 
     @Transactional
-    public void startTask(final StudentRecordAITask task) {
-        task.start();
-    }
-
-    @Transactional
     public void completeAITask(final Long taskId) {
         StudentRecordAITask aiTask = aiTaskRepository.findById(taskId)
                 .orElseThrow(() -> new StudentRecordException(StudentRecordErrorCode.AI_TASK_NOT_FOUND));

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/AITaskService.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/AITaskService.java
@@ -34,10 +34,18 @@ public class AITaskService {
         aiTask.complete();
     }
 
-    public void validateUserTask(final long memberId, final long taskId) {
-        boolean exists = aiTaskRepository.existsByIdAndMemberId(taskId, memberId);
+    public void validateUserTask(final long memberId, final String taskId) {
+        boolean exists = aiTaskRepository.existsByIdAndMemberId(parseTaskId(taskId), memberId);
         if (!exists) {
             throw new StudentRecordException(StudentRecordErrorCode.AI_TASK_NOT_FOUND);
+        }
+    }
+
+    private long parseTaskId(final String taskId) {
+        try {
+            return Long.parseLong(taskId);
+        } catch (NumberFormatException e) {
+            throw new StudentRecordException(StudentRecordErrorCode.NUMBER_FORMAT_EXCEPTION);
         }
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
@@ -76,7 +76,7 @@ public class SSEChannelManager {
                 emitter.send(SseEmitter.event()
                         .name("ai-progress")
                         .data(message));
-                log.info("Sent progress message to SSE channel for taskId: {}, status: {}", taskId, message.status());
+                log.info("Sent progress message to SSE channel for taskId: {}, status: {}", taskId, message.message());
             } catch (IOException e) {
                 log.error("Failed to send progress message to SSE channel for taskId: {}", taskId, e);
                 removeChannel(taskId);

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
@@ -2,6 +2,7 @@ package com.edukit.core.studentrecord.service;
 
 import com.edukit.common.infra.ServerInstanceManager;
 import com.edukit.core.common.event.ai.dto.AIResponseMessage;
+import com.edukit.core.common.event.ai.dto.AIProgressMessage;
 import com.edukit.core.common.service.RedisStoreService;
 import com.edukit.core.studentrecord.exception.StudentRecordErrorCode;
 import com.edukit.core.studentrecord.exception.StudentRecordException;
@@ -63,6 +64,21 @@ public class SSEChannelManager {
                 }
             } catch (IOException e) {
                 log.error("Failed to send message to SSE channel for taskId: {}", taskId, e);
+                removeChannel(taskId);
+            }
+        }
+    }
+
+    public void sendProgressMessage(final String taskId, final AIProgressMessage message) {
+        SseEmitter emitter = activeChannels.get(taskId);
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("ai-progress")
+                        .data(message));
+                log.info("Sent progress message to SSE channel for taskId: {}, status: {}", taskId, message.status());
+            } catch (IOException e) {
+                log.error("Failed to send progress message to SSE channel for taskId: {}", taskId, e);
                 removeChannel(taskId);
             }
         }

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/SSEChannelManager.java
@@ -51,8 +51,7 @@ public class SSEChannelManager {
                 emitter.send(SseEmitter.event()
                         .name(SSE_EVENT_NAME)
                         .data(sseMessage));
-                log.info("Sent stored progress message to SSE channel for taskId: {}, message: {}", taskId,
-                        currentStatus);
+                log.info("Sent stored progress message to SSE channel for taskId: {}, message: {}", taskId, message);
             } catch (IOException e) {
                 log.error("Failed to send stored progress message to SSE channel for taskId: {}", taskId, e);
                 removeChannel(taskId);

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/enums/AITaskStatus.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/enums/AITaskStatus.java
@@ -1,5 +1,7 @@
 package com.edukit.core.studentrecord.service.enums;
 
+import com.edukit.core.studentrecord.exception.StudentRecordErrorCode;
+import com.edukit.core.studentrecord.exception.StudentRecordException;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -7,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AITaskStatus {
-
     PHASE1_STARTED("PHASE1_STARTED", "3가지 버전 생성 중"),
     PHASE1_COMPLETED("PHASE1_COMPLETED", "3가지 버전 생성 완료");
 
@@ -19,6 +20,6 @@ public enum AITaskStatus {
                 .filter(aiTaskStatus -> aiTaskStatus.getStatus().equals(status))
                 .map(AITaskStatus::getMessage)
                 .findFirst()
-                .orElse(null);
+                .orElseThrow(() -> new StudentRecordException(StudentRecordErrorCode.INVALID_AI_TASK_STATUS));
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/studentrecord/service/enums/AITaskStatus.java
+++ b/edukit-core/src/main/java/com/edukit/core/studentrecord/service/enums/AITaskStatus.java
@@ -1,0 +1,24 @@
+package com.edukit.core.studentrecord.service.enums;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AITaskStatus {
+
+    PHASE1_STARTED("PHASE1_STARTED", "3가지 버전 생성 중"),
+    PHASE1_COMPLETED("PHASE1_COMPLETED", "3가지 버전 생성 완료");
+
+    private final String status;
+    private final String message;
+
+    public static String getMessageByStatus(final String status) {
+        return Arrays.stream(values())
+                .filter(aiTaskStatus -> aiTaskStatus.getStatus().equals(status))
+                .map(AITaskStatus::getMessage)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
+++ b/edukit-external/src/main/java/com/edukit/external/aws/sqs/SqsServiceImpl.java
@@ -6,6 +6,7 @@ import com.edukit.external.aws.sqs.exception.SQSErrorCode;
 import com.edukit.external.aws.sqs.exception.SQSException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -103,9 +104,9 @@ public class SqsServiceImpl implements SqsService {
     private String extractIdempotencyKey(final Object message) {
         try {
             if (message.getClass().getSimpleName().equals("DraftGenerationEvent")) {
-                java.lang.reflect.Method getTaskId = message.getClass().getMethod("taskId");
-                java.lang.reflect.Method getVersion = message.getClass().getMethod("version");
-                long taskId = (Long) getTaskId.invoke(message);
+                Method getTaskId = message.getClass().getMethod("taskId");
+                Method getVersion = message.getClass().getMethod("version");
+                String taskId = (String) getTaskId.invoke(message);
                 int version = (Integer) getVersion.invoke(message);
                 String idempotencyKey = taskId + "-" + version;
                 log.debug("멱등성 키 생성: {}", idempotencyKey);


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-406]


## 👩‍💻 작업 내용
OpenAI를 통한 생기부 응답 생성 시, 단계별 진행 상황을 전송하는 기능을 추가하였습니다.

## 📸 스크린 샷
<img width="815" height="175" alt="image" src="https://github.com/user-attachments/assets/871a914a-2971-46fc-9128-116e4e955ad4" />

[EDMT-406]: https://bbangbbangz.atlassian.net/browse/EDMT-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - AI 버전 생성의 실시간 진행 알림 추가: 시작/완료 PROGRESS 메시지 제공
  - PROGRESS와 RESPONSE를 구분하는 구조화된 이벤트 스트림 제공(타입별 페이로드, 이벤트명 변경)
- 리팩터링
  - SSE 페이로드를 통일된 이벤트 envelope로 표준화; taskId가 문자열로 변경되어 스트리밍 식별 일관성 향상
- 작업
  - 학생 기록 AI 작업의 상태 컬럼 제거 및 상태 관리 로직 정리
- 기타
  - 잘못된 taskId 입력에 대한 명확한 오류 코드 추가 (숫자 형식 예외)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->