### PR TITLE
[EDMT-450] 블루-그린 배포 JMX 포트 충돌 해결: 메트릭 수집 포트 재배치

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,10 +6,10 @@ services:
       PROFILE: dev
       TZ: Asia/Seoul
       HOSTNAME: ${HOSTNAME_BLUE:-dev-1-blue}
-      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=8081:/app/jmx-config.yml"
+      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=9081:/app/jmx-config.yml"
     ports:
       - "8080:8080"
-      - "8081:8081"
+      - "9081:9081"
     env_file:
       - .env
     restart: always
@@ -27,10 +27,10 @@ services:
       PROFILE: dev
       TZ: Asia/Seoul
       HOSTNAME: ${HOSTNAME_GREEN:-dev-1-green}
-      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=8082:/app/jmx-config.yml"
+      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=9082:/app/jmx-config.yml"
     ports:
       - "8081:8080"
-      - "8082:8082"
+      - "9082:9082"
     env_file:
       - .env
     restart: always

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,10 +6,10 @@ services:
       PROFILE: prod
       TZ: Asia/Seoul
       HOSTNAME: ${HOSTNAME_BLUE:-prod-1-blue}
-      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=8081:/app/jmx-config.yml"
+      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=9081:/app/jmx-config.yml"
     ports:
       - "8080:8080"
-      - "8081:8081"
+      - "9081:9081"
     env_file:
       - .env
     restart: always
@@ -27,10 +27,10 @@ services:
       PROFILE: prod
       TZ: Asia/Seoul
       HOSTNAME: ${HOSTNAME_GREEN:-prod-1-green}
-      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=8082:/app/jmx-config.yml"
+      JAVA_OPTS: "-javaagent:/app/jmx_prometheus_javaagent.jar=9082:/app/jmx-config.yml"
     ports:
       - "8081:8080"
-      - "8082:8082"
+      - "9082:9082"
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
## 📣 Jira Ticket
[EDMT-450]

## 👩‍💻 작업 내용

### 🚨 블루-그린 배포 포트 충돌 문제 해결
- **문제 상황**: JMX 메트릭 포트가 블루-그린 배포 플로우와 충돌
  - Blue 인스턴스 JMX 포트 8081 ← Green 인스턴스 앱 포트 8081 충돌
  - 배포 중 포트 바인딩 실패로 Green 컨테이너 시작 불가

### 🔧 JMX 포트 재배치
**개발환경 (docker-compose.dev.yml):**
```
이전: Blue JMX=8081, Green JMX=8082
변경: Blue JMX=9081, Green JMX=9082
```

**운영환경 (docker-compose.prod.yml):**
```
이전: Blue JMX=8081, Green JMX=8082  
변경: Blue JMX=9081, Green JMX=9082
```

### 📊 수정된 포트 매핑
| 인스턴스 | 앱 포트 | JMX 포트 (이전) | JMX 포트 (변경) |
|----------|---------|------------------|------------------|
| **Blue** | 8080 | 8081 ❌ | 9081 ✅ |
| **Green** | 8081 | 8082 ❌ | 9082 ✅ |

### 🎯 배포 플로우 개선
1. **Blue 실행 중** (8080 앱, 9081 JMX)
2. **Green 배포** (8081 앱, 9082 JMX) ✅ 포트 충돌 없음
3. **트래픽 전환** nginx upstream 변경
4. **Blue 종료** ✅ 깔끔한 리소스 정리

## 📝 리뷰 요청 & 논의하고 싶은 내용

- JMX 포트 변경에 따른 모니터링 도구 설정 업데이트 필요성
- 운영 환경 방화벽에서 신규 포트 (9081, 9082) 허용 설정
- Prometheus 수집 설정에서 새로운 포트로 엔드포인트 변경

## Test Plan
### ✅ Manual Testing Checklist
- [ ] 개발환경에서 블루-그린 배포 테스트 (포트 충돌 없이 정상 동작)
- [ ] Blue 인스턴스 JMX 메트릭 수집 확인 (9081 포트)
- [ ] Green 인스턴스 JMX 메트릭 수집 확인 (9082 포트)
- [ ] 배포 중 두 인스턴스 동시 실행 시 포트 충돌 없음 확인
- [ ] nginx upstream 전환 시 JMX 메트릭 연속성 확인
- [ ] 기존 앱 포트 (8080, 8081) 정상 동작 확인

### 🧪 Automated Tests
- [ ] Docker Compose 파일 문법 검증: `docker-compose config`
- [ ] 컨테이너 시작/중지 테스트: `./gradlew build`
- [ ] 포트 바인딩 테스트 (개발환경)
- [ ] JMX 엔드포인트 접근성 테스트

### 🔍 Code Quality
- [ ] Docker Compose 설정 리뷰 완료
- [ ] 포트 매핑 일관성 확인 (dev/prod 환경)
- [ ] JMX agent 설정 검증
- [ ] 배포 플로우 문서화 업데이트

## Deployment Notes
- [ ] **중요**: 운영 환경 방화벽에서 9081, 9082 포트 허용 설정 추가
- [ ] Prometheus 수집 job에서 target 포트 변경:
  ```yaml
  # 이전: localhost:8081, localhost:8082
  # 변경: localhost:9081, localhost:9082
  ```
- [ ] Grafana 대시보드에서 데이터소스 포트 확인
- [ ] 모니터링 알림 규칙에서 새 포트 반영
- [ ] 기존 JMX 수집 설정 제거 (8081, 8082)

## 🔧 기술적 세부사항
### JMX Agent 설정 변경:
```bash
# Blue 인스턴스
JAVA_OPTS="-javaagent:/app/jmx_prometheus_javaagent.jar=9081:/app/jmx-config.yml"

# Green 인스턴스  
JAVA_OPTS="-javaagent:/app/jmx_prometheus_javaagent.jar=9082:/app/jmx-config.yml"
```

### 메트릭 수집 엔드포인트:
```bash
# 개발환경
curl http://localhost:9081/metrics  # Blue
curl http://localhost:9082/metrics  # Green

# 운영환경
curl http://prod-server:9081/metrics
curl http://prod-server:9082/metrics
```

🤖 Generated with Claude Code