### PR TITLE
[EDMT-457] 회원 포인트 시스템 구현 및 AI 생성 시 포인트 차감 기능 추가

### DIFF
--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -35,9 +35,9 @@ public class StudentRecordAIFacade {
     @AIGenerationMetrics
     public StudentRecordTaskResponse createTaskId(final long memberId, final long recordId, final int byteCount,
                                                   final String userPrompt) {
-        Member member = memberService.getMemberById(memberId);
-        pointService.deductPoints(member, DEDUCTED_POINTS);
+        pointService.deductPoints(memberId, DEDUCTED_POINTS);
 
+        Member member = memberService.getMemberById(memberId);
         StudentRecord studentRecord = studentRecordService.getRecordDetail(memberId, recordId);
 
         String requestPrompt = AIPromptGenerator.createStreamingPrompt(studentRecord.getStudentRecordType(), byteCount, userPrompt);

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -29,12 +29,14 @@ public class StudentRecordAIFacade {
     private final SSEChannelManager sseChannelManager;
     private final ApplicationEventPublisher eventPublisher;
 
+    private static final int DEDUCTED_POINTS = 100;
+
     @Transactional
     @AIGenerationMetrics
     public StudentRecordTaskResponse createTaskId(final long memberId, final long recordId, final int byteCount,
                                                   final String userPrompt) {
         Member member = memberService.getMemberById(memberId);
-        pointService.checkSufficientPoints(member);
+        pointService.deductPoints(member, DEDUCTED_POINTS);
 
         StudentRecord studentRecord = studentRecordService.getRecordDetail(memberId, recordId);
 

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -3,6 +3,7 @@ package com.edukit.studentrecord.facade;
 import com.edukit.common.annotation.AIGenerationMetrics;
 import com.edukit.core.member.db.entity.Member;
 import com.edukit.core.member.service.MemberService;
+import com.edukit.core.member.service.PointService;
 import com.edukit.core.studentrecord.db.entity.StudentRecord;
 import com.edukit.core.studentrecord.db.entity.StudentRecordAITask;
 import com.edukit.core.studentrecord.service.AITaskService;
@@ -22,6 +23,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class StudentRecordAIFacade {
 
     private final MemberService memberService;
+    private final PointService pointService;
     private final AITaskService aiTaskService;
     private final StudentRecordService studentRecordService;
     private final SSEChannelManager sseChannelManager;
@@ -32,6 +34,8 @@ public class StudentRecordAIFacade {
     public StudentRecordTaskResponse createTaskId(final long memberId, final long recordId, final int byteCount,
                                                   final String userPrompt) {
         Member member = memberService.getMemberById(memberId);
+        pointService.checkSufficientPoints(member);
+
         StudentRecord studentRecord = studentRecordService.getRecordDetail(memberId, recordId);
 
         String requestPrompt = AIPromptGenerator.createStreamingPrompt(studentRecord.getStudentRecordType(), byteCount, userPrompt);

--- a/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
+++ b/edukit-api/src/main/java/com/edukit/studentrecord/facade/StudentRecordAIFacade.java
@@ -35,9 +35,8 @@ public class StudentRecordAIFacade {
     @AIGenerationMetrics
     public StudentRecordTaskResponse createTaskId(final long memberId, final long recordId, final int byteCount,
                                                   final String userPrompt) {
-        pointService.deductPoints(memberId, DEDUCTED_POINTS);
+        Member member = pointService.deductPoints(memberId, DEDUCTED_POINTS);
 
-        Member member = memberService.getMemberById(memberId);
         StudentRecord studentRecord = studentRecordService.getRecordDetail(memberId, recordId);
 
         String requestPrompt = AIPromptGenerator.createStreamingPrompt(studentRecord.getStudentRecordType(), byteCount, userPrompt);

--- a/edukit-api/src/main/resources/db/migration/V10__Add_member_point.sql
+++ b/edukit-api/src/main/resources/db/migration/V10__Add_member_point.sql
@@ -1,0 +1,3 @@
+-- Add point column to member table
+alter table member
+    add column point int not null default 1000;

--- a/edukit-core/src/main/java/com/edukit/core/member/db/entity/Member.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/db/entity/Member.java
@@ -58,6 +58,9 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
+    @Column(nullable = false)
+    private int point;
+
     @Column
     private LocalDateTime verifiedAt;
 
@@ -66,16 +69,19 @@ public class Member extends BaseTimeEntity {
 
     private LocalDateTime deletedAt;
 
+    private static final int INITIAL_POINT = 1000;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Member(final Subject subject, final String email, final String password, final String nickname,
                    final School school, final MemberRole role, final LocalDateTime verifiedAt, final boolean isDeleted,
-                   final LocalDateTime deletedAt, final String memberUuid) {
+                   final LocalDateTime deletedAt, final String memberUuid, final int point) {
         this.subject = subject;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.school = school;
         this.role = role;
+        this.point = point;
         this.verifiedAt = verifiedAt;
         this.isDeleted = isDeleted;
         this.deletedAt = deletedAt;
@@ -92,6 +98,7 @@ public class Member extends BaseTimeEntity {
                 .school(school)
                 .role(memberRole)
                 .isDeleted(false)
+                .point(INITIAL_POINT)
                 .memberUuid(UUID.randomUUID().toString())
                 .build();
     }

--- a/edukit-core/src/main/java/com/edukit/core/member/db/entity/Member.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/db/entity/Member.java
@@ -146,4 +146,8 @@ public class Member extends BaseTimeEntity {
         this.email = email;
         this.role = MemberRole.PENDING_TEACHER;
     }
+
+    public void deductPoints(final int pointsToDeduct) {
+        this.point -= pointsToDeduct;
+    }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/db/repository/MemberRepository.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/db/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.edukit.core.member.db.repository;
 
 import com.edukit.core.member.db.entity.Member;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,4 +22,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM Member m JOIN FETCH m.subject WHERE m.id = :id AND m.isDeleted = :isDeleted")
     Optional<Member> findByIdAndIsDeletedFetchJoinSubject(@Param("id") long id, @Param("isDeleted") boolean isDeleted);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM Member m WHERE m.id = :id AND m.isDeleted = false")
+    Optional<Member> findByIdWithLock(@Param("id") Long id);
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/exception/MemberErrorCode.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/exception/MemberErrorCode.java
@@ -15,7 +15,8 @@ public enum MemberErrorCode implements ErrorCode {
     DUPLICATED_NICKNAME("M-40005", "입력하신 닉네임은 중복된 닉네임입니다."),
     INVALID_CURRENT_PASSWORD("M-40006", "현재 비밀번호가 일치하지 않습니다. 다시 입력해주세요."),
     SAME_PASSWORD("M-40007", "새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다."),
-    DUPLICATED_EMAIL("M-40908", "이미 등록된 이메일입니다.");
+    DUPLICATED_EMAIL("M-40908", "이미 등록된 이메일입니다."),
+    INSUFFICIENT_POINTS("M-40009", "포인트가 부족합니다.");
 
     private final String code;
     private final String message;

--- a/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
@@ -15,7 +15,7 @@ public class PointService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void deductPoints(final Long memberId, final int pointsToDeduct) {
+    public Member deductPoints(final Long memberId, final int pointsToDeduct) {
         Member member = memberRepository.findByIdWithLock(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
@@ -26,5 +26,6 @@ public class PointService {
         }
 
         member.deductPoints(pointsToDeduct);
+        return member;
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
@@ -1,6 +1,7 @@
 package com.edukit.core.member.service;
 
 import com.edukit.core.member.db.entity.Member;
+import com.edukit.core.member.db.repository.MemberRepository;
 import com.edukit.core.member.exception.MemberErrorCode;
 import com.edukit.core.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
@@ -11,13 +12,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PointService {
 
-    private static final int MINIMUM_REQUIRED_POINTS = 100;
+    private final MemberRepository memberRepository;
 
-    @Transactional(readOnly = true)
-    public void deductPoints(final Member member, final int pointsToDeduct) {
-        int point = member.getPoint();
+    @Transactional
+    public void deductPoints(final Long memberId, final int pointsToDeduct) {
+        Member member = memberRepository.findByIdWithLock(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        if (point < MINIMUM_REQUIRED_POINTS) {
+        int currentPoint = member.getPoint();
+
+        if (currentPoint < pointsToDeduct) {
             throw new MemberException(MemberErrorCode.INSUFFICIENT_POINTS);
         }
 

--- a/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
@@ -1,7 +1,6 @@
 package com.edukit.core.member.service;
 
 import com.edukit.core.member.db.entity.Member;
-import com.edukit.core.member.db.repository.MemberRepository;
 import com.edukit.core.member.exception.MemberErrorCode;
 import com.edukit.core.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
@@ -12,16 +11,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PointService {
 
-    private final MemberRepository memberRepository;
-
     private static final int MINIMUM_REQUIRED_POINTS = 100;
 
     @Transactional(readOnly = true)
-    public void checkSufficientPoints(final Member member) {
+    public void deductPoints(final Member member, final int pointsToDeduct) {
         int point = member.getPoint();
 
         if (point < MINIMUM_REQUIRED_POINTS) {
             throw new MemberException(MemberErrorCode.INSUFFICIENT_POINTS);
         }
+
+        member.deductPoints(pointsToDeduct);
     }
 }

--- a/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
+++ b/edukit-core/src/main/java/com/edukit/core/member/service/PointService.java
@@ -1,0 +1,27 @@
+package com.edukit.core.member.service;
+
+import com.edukit.core.member.db.entity.Member;
+import com.edukit.core.member.db.repository.MemberRepository;
+import com.edukit.core.member.exception.MemberErrorCode;
+import com.edukit.core.member.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+    private final MemberRepository memberRepository;
+
+    private static final int MINIMUM_REQUIRED_POINTS = 100;
+
+    @Transactional(readOnly = true)
+    public void checkSufficientPoints(final Member member) {
+        int point = member.getPoint();
+
+        if (point < MINIMUM_REQUIRED_POINTS) {
+            throw new MemberException(MemberErrorCode.INSUFFICIENT_POINTS);
+        }
+    }
+}


### PR DESCRIPTION
## 📣 Jira Ticket
[EDMT-457](https://your-jira-instance/browse/EDMT-457)

## 👩‍💻 작업 내용

회원 포인트 시스템을 구현하고 AI 생성 시 포인트 차감 기능을 추가했습니다.

### 주요 변경사항

1. **회원 엔티티에 포인트 필드 추가**
   - `Member` 엔티티에 `point` 컬럼 추가 (기본값: 1000)
   - DB 마이그레이션 스크립트 작성 (V10)

2. **포인트 차감 로직 구현**
   - `PointService` 신규 생성
   - 비관적 락(Pessimistic Lock)을 사용한 동시성 제어
   - 포인트 부족 시 예외 처리 (`INSUFFICIENT_POINTS` 에러 코드 추가)

3. **AI 생성 시 포인트 차감 통합**
   - `StudentRecordAIFacade`에서 AI 작업 생성 시 100 포인트 차감
   - 포인트 검증 및 차감 후 AI 작업 진행

### 기술적 구현

- **동시성 제어**: `@Lock(LockModeType.PESSIMISTIC_WRITE)`를 사용하여 포인트 차감 시 동시성 문제 방지
- **트랜잭션 관리**: `@Transactional`을 통한 원자적 작업 보장
- **에러 처리**: 포인트 부족 시 명확한 에러 메시지 제공

## 📝 리뷰 요청 & 논의하고 싶은 내용

1. **포인트 차감량**: 현재 AI 생성당 100 포인트를 차감하는데, 이 값이 적절한지 검토 부탁드립니다.
2. **락 전략**: 비관적 락을 사용했는데, 낙관적 락이나 다른 전략도 고려해볼 수 있을 것 같습니다.
3. **포인트 충전 로직**: 현재는 차감만 구현되어 있는데, 향후 포인트 충전/지급 로직도 필요할 것 같습니다.

## Test Plan

### ✅ Manual Testing Checklist
- [ ] 신규 회원 가입 시 기본 1000 포인트 부여 확인
- [ ] AI 생성 요청 시 100 포인트 차감 확인
- [ ] 포인트 부족 시 적절한 에러 메시지 반환 확인
- [ ] 동시에 여러 AI 생성 요청 시 포인트 차감이 정확한지 확인 (동시성 테스트)
- [ ] 기존 회원 데이터 마이그레이션 확인 (기본 1000 포인트 부여)

### 🧪 Automated Tests
- [ ] Unit tests pass: `./gradlew test`
- [ ] Integration tests pass
- [ ] Build succeeds: `./gradlew build`
- [ ] `PointService` 단위 테스트 (포인트 차감, 부족 시 예외)
- [ ] `StudentRecordAIFacade` 통합 테스트

### 🔍 Code Quality
- [ ] Code review completed
- [ ] No new warnings or errors
- [ ] Security considerations reviewed (동시성 제어)
- [ ] Exception handling verified

## Deployment Notes
- [x] Database migrations included (V10__Add_member_point.sql)
- [ ] Environment variables updated (N/A)
- [ ] AWS resources configured (N/A)
- [ ] **중요**: 배포 시 기존 회원들에게 기본 1000 포인트가 부여되는지 확인 필요

## 관련 커밋
- `298f392` - [feat] add point column to Member entity and initialize with default value
- `44c0097` - [feat] implement point validation for member actions
- `6c44296` - [feat] implement point deduction logic in Member and PointService
- `0d099c3` - [feat] implement pessimistic locking for point deduction in PointService
- `350aeec` - [refac] update deductPoints method to return Member object in PointService

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDMT-457]: https://bbangbbangz.atlassian.net/browse/EDMT-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 사용자 포인트 시스템 추가 (모든 사용자는 1,000포인트로 시작)
  * 작업 생성 시 자동으로 100포인트 차감
  * 포인트 부족 시 작업 생성 차단 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->